### PR TITLE
docs: split character evolution plan into staged task specs

### DIFF
--- a/doc/01-character-status-tracking.md
+++ b/doc/01-character-status-tracking.md
@@ -1,0 +1,233 @@
+# 阶段一子任务设计：角色状态追踪核心能力
+
+## 1. 背景与目标
+- **业务目标**：让系统能够随章节追踪每位角色的认知和状态变化，为后续关系演化、记忆驱动生成等高级能力打下数据基础。
+- **交付边界**：本阶段仅覆盖角色状态变动的采集、存储、展示，不含关系图谱、对话生成、转折点等扩展能力。
+- **关键痛点**：目前稿件系统只保存正文，缺乏结构化的角色动态信息，作者无法快速回溯角色认知，AI 也无法感知角色演化。
+
+## 2. 涉及系统与依赖
+| 层级 | 受影响的模块 | 说明 |
+| --- | --- | --- |
+| 数据层 | MySQL (`backend/src/database.sql`) | 新增角色变动记录表、索引与软删除字段 |
+| 后端 | Spring Boot (`backend/src/main/java/com/example/ainovel`) | 新增实体、仓储、服务、控制器接口，扩展 `ManuscriptService` 逻辑 |
+| AI 调用 | `OpenAiService` | 需要新增 JSON 输出的分析 Prompt 以及解析逻辑 |
+| 前端 | React + Ant Design (`frontend/src`) | 扩展 `ManuscriptWriter`、新增 `CharacterStatusSidebar`、新增 API 封装与类型 |
+| 认证授权 | Spring Security | 复用现有权限校验逻辑，确保用户只能分析自己稿件 |
+
+## 3. 数据库与实体设计
+### 3.1 新表 `character_change_logs`
+- 新建表文件位置：`backend/src/database.sql` 添加建表语句；若后续引入 Flyway/Liquibase 可再拆分脚本。
+- 字段定义：
+  | 字段 | 类型 | 约束 | 说明 |
+  | --- | --- | --- | --- |
+  | `id` | BIGINT | PK, AUTO_INCREMENT | 主键 |
+  | `character_id` | BIGINT | NOT NULL | 外键 -> `character_cards.id` |
+  | `manuscript_id` | BIGINT | NOT NULL | 外键 -> `manuscripts.id` |
+  | `scene_id` | BIGINT | NOT NULL | 对应大纲场景 ID，便于按场景检索 |
+  | `outline_id` | BIGINT | NOT NULL | 外键 -> `outline_cards.id`，与稿件保持一致 |
+  | `chapter_number` | INT | NOT NULL | 数字章节（`OutlineChapter.chapterNumber`） |
+  | `section_number` | INT | NOT NULL | 数字小节（`OutlineScene.sceneNumber`） |
+  | `newly_known_info` | TEXT | NULL | 本节角色获知的新信息 |
+  | `character_changes` | TEXT | NULL | 角色在本节发生的变化 |
+  | `character_details_after` | LONGTEXT | NOT NULL | 本节结束后角色的完整画像 |
+  | `is_auto_copied` | BOOLEAN | NOT NULL DEFAULT FALSE | 当 AI 判定无变化时复制上一条详情并置为 true |
+  | `created_at` | DATETIME | NOT NULL DEFAULT CURRENT_TIMESTAMP | 创建时间 |
+  | `updated_at` | DATETIME | NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP | 更新时间 |
+  | `deleted_at` | DATETIME | NULL | 软删除时间 |
+- 索引建议：
+  - `IDX_ccl_character` (`character_id`, `manuscript_id`)
+  - `IDX_ccl_scene` (`manuscript_id`, `scene_id`, `chapter_number`, `section_number`)
+  - `IDX_ccl_turning` (`manuscript_id`, `character_id`, `deleted_at`) 便于过滤。
+- 软删除：
+  - 在实体上使用 `@SQLDelete` 和 `@Where(deleted_at IS NULL)` 控制。
+  - 删除操作默认打标 `deleted_at`，保留历史数据。
+
+### 3.2 JPA 实体 `CharacterChangeLog`
+- 位置：`backend/src/main/java/com/example/ainovel/model/CharacterChangeLog.java`
+- 关键设计：
+  - `@ManyToOne` 关联 `CharacterCard`、`Manuscript`、`OutlineCard`；`sceneId`、`chapterNumber`、`sectionNumber` 使用普通列。
+  - `characterDetailsAfter` 使用 `@Lob(columnDefinition = "LONGTEXT")` 以容纳大文本。
+  - 审计字段使用 `@CreationTimestamp` / `@UpdateTimestamp`。
+  - 提供便捷方法：
+    - `copyFrom(CharacterChangeLog previous)`：复制上一条详情并将 `isAutoCopied` 设为 true。
+    - `buildTimelineKey()`：返回 `chapterNumber-sectionNumber`，用于排序。
+
+### 3.3 仓储接口 `CharacterChangeLogRepository`
+- 位置：`backend/src/main/java/com/example/ainovel/repository`
+- 方法清单：
+  - `Optional<CharacterChangeLog> findFirstByCharacter_IdAndManuscript_IdAndDeletedAtIsNullOrderByChapterNumberDescSectionNumberDescCreatedAtDesc(Long characterId, Long manuscriptId)`：获取角色上一条有效记录。
+  - `List<CharacterChangeLog> findByManuscript_IdAndSceneIdAndDeletedAtIsNullOrderByCharacter_Id(Long manuscriptId, Long sceneId)`：用于当前场景展示。
+  - `List<CharacterChangeLog> findByCharacter_IdAndManuscript_IdAndDeletedAtIsNullOrderByChapterNumberAscSectionNumberAsc(Long characterId, Long manuscriptId)`：后续阶段重用。
+
+## 4. 后端服务与 API 设计
+### 4.1 DTO 层
+- `AnalyzeCharacterChangesRequest` (`backend/src/main/java/com/example/ainovel/dto`)
+  - 字段：`sceneId`、`chapterNumber`、`sectionNumber`、`sectionContent`、`characterIds: List<Long>`、`outlineId`（冗余校验用）。
+  - 前端传入章节编号；后端会通过 sceneId 反查并校验，若不一致则以后端数据为准。
+- `CharacterChangeLogResponse`
+  - 字段：`characterId`、`newlyKnownInfo`、`characterChanges`、`characterDetailsAfter`、`isAutoCopied`、`chapterNumber`、`sectionNumber`、`createdAt`、`logId`。
+- 返回体：`List<CharacterChangeLogResponse>`。
+
+### 4.2 新增服务 `CharacterChangeLogService`
+- 位置：`backend/src/main/java/com/example/ainovel/service`
+- 职责：
+  1. 校验稿件与场景归属（复用 `ManuscriptService` 中的 `validateManuscriptAccess`）。
+  2. 根据 `sceneId` 解析 `chapterNumber`、`sectionNumber`、`outlineId`，防止前端篡改。
+  3. 汇总角色上下文：
+     - `previousDetails`：优先取上一条日志的 `characterDetailsAfter`；如无则使用 `CharacterCard.details`。
+     - `baselineSummary`：角色卡 Synopsis，用于 Prompt。
+  4. 调用 AI（详见 5 节），解析结果。
+  5. 将结果持久化为 `CharacterChangeLog`。
+  6. 返回最新记录（保存后刷新实体）。
+- 主要方法：
+  - `List<CharacterChangeLog> analyzeAndPersist(Long manuscriptId, AnalyzeCharacterChangesRequest req, Long userId)`。
+  - `List<CharacterChangeLog> getLogsForScene(Long manuscriptId, Long sceneId, Long userId)`。
+
+### 4.3 控制器扩展
+- 在 `ManuscriptController` 下新增接口：
+  ```java
+  @PostMapping("/manuscripts/{manuscriptId}/sections/analyze-character-changes")
+  public ResponseEntity<List<CharacterChangeLogResponse>> analyzeCharacterChanges(
+      @PathVariable Long manuscriptId,
+      @RequestBody AnalyzeCharacterChangesRequest request,
+      @AuthenticationPrincipal User user)
+  ```
+- 校验：
+  - `manuscriptId` 必须属于当前登录用户。
+  - `sceneId` 必须属于稿件关联的大纲；若缺失或不匹配返回 400。
+  - `characterIds` 为空则返回 400。
+- 新增 `@GetMapping("/manuscripts/{manuscriptId}/sections/{sceneId}/character-change-logs")` 用于加载已有记录（页面初始化或切换场景时调用）。
+
+### 4.4 与 `ManuscriptService` 的协作
+- `ManuscriptService` 保持生成/保存正文的逻辑不变。
+- 对外提供便捷方法：
+  - `public List<CharacterChangeLog> analyzeCharacterChanges(Long manuscriptId, AnalyzeCharacterChangesRequest req, Long userId)` 代理至 `CharacterChangeLogService`，以减少控制器对多个服务的依赖。
+- 生成正文后由前端再次调用分析接口；后端不自动触发，避免阻塞原写作流程。
+
+## 5. AI 交互设计
+### 5.1 Prompt 结构
+- 新增工具类 `CharacterChangePromptBuilder`（或放入 `CharacterChangeLogService` 内部）：
+  ```
+  你是小说编辑，负责追踪角色状态。请根据提供的信息判断角色是否在本小节发生变化。
+  【角色既有设定】
+  - 基础档案: {{characterSynopsis}}
+  - 上一次记录的角色详情: {{previousDetails}}
+  【本节正文】
+  {{sectionContent}}
+  任务：
+  1. 分析角色在本节新增认知或信息，使用第一人称/第三人称均可。
+  2. 总结角色状态（心理、生理、外貌、人际态度等）发生的变化。
+  3. 输出本节结束后的最新角色详情，需完整覆盖角色核心设定，允许保留未变化的描述。
+  输出格式必须是 JSON：
+  {
+    "newly_known_info": "string，可为空字符串",
+    "character_changes": "string，可为空字符串",
+    "character_details_after": "string",
+    "no_change": true/false
+  }
+  若确无变化，将 newly_known_info 和 character_changes 置为 ""，并将 no_change 设为 true。
+  ```
+- 采用 `OpenAiService.callOpenAi(..., jsonMode=true)` 获得 JSON。
+- 出错处理：
+  - 若 AI 响应缺失 `character_details_after`，抛出 502 并记录日志。
+  - 若 `no_change=true`，则复制上一条详情并设置 `is_auto_copied=true`。
+
+### 5.2 Token 控制与重试
+- 依赖现有 `SettingsService` 获取用户 API Key / Base URL / Model。
+- 使用 `@Retryable`（已在 `OpenAiService` 中实现）。
+- 对于多角色请求：串行调用保证上下文清晰；若后期性能受限再考虑批量 Prompt。
+
+## 6. 前端设计
+### 6.1 类型与 API
+- `frontend/src/types.ts` 新增：
+  ```ts
+  export interface CharacterChangeLog {
+    id: number;
+    characterId: number;
+    chapterNumber: number;
+    sectionNumber: number;
+    newlyKnownInfo?: string;
+    characterChanges?: string;
+    characterDetailsAfter: string;
+    isAutoCopied: boolean;
+    createdAt: string;
+  }
+  ```
+- `frontend/src/services/api.ts` 新增函数：
+  - `analyzeCharacterChanges(manuscriptId: number, payload: AnalyzeCharacterChangesPayload): Promise<CharacterChangeLog[]>`
+  - `fetchCharacterChangeLogs(manuscriptId: number, sceneId: number): Promise<CharacterChangeLog[]>`
+- `AnalyzeCharacterChangesPayload` 定义在同文件或 `types.ts` 中，包含 `sceneId`, `chapterNumber`, `sectionNumber`, `sectionContent`, `characterIds`。
+
+### 6.2 `ManuscriptWriter.tsx` 调整
+- 额外加载角色列表：当 `selectedStoryId` 变化时调用 `fetchStoryDetails` 获取 `characterCards`，缓存为 `characterMap`（`id -> CharacterCard`）。
+- 本地状态：
+  - `const [characterChangeLogs, setCharacterChangeLogs] = useState<Record<number, CharacterChangeLog[]>>({}); // key = sceneId`
+  - `const [isAnalyzing, setIsAnalyzing] = useState(false);`
+- 场景切换时：调用 `fetchCharacterChangeLogs`，更新 `characterChangeLogs[sceneId]`。
+- 在 `handleGenerateContent` 与 `handleSaveContent` 成功后追加：
+  ```ts
+  await runCharacterAnalysis(sectionContent, selectedSceneId);
+  ```
+  - `runCharacterAnalysis` 将 `sectionContent`、`selectedScene?.sceneNumber`、`chapterNumber`（需从 `selectedOutlineDetail` 中找到对应章节）以及 `presentCharacterIds` 传入。
+  - 若无角色 ID，提示用户补齐大纲数据。
+- UI 调整：
+  - 将原布局改为三列：大纲树（span=6）、正文编辑（span=12）、角色侧栏（span=6）。
+  - 在右侧渲染 `<CharacterStatusSidebar>`，传入 `characters`、`logs`、`chapterNumber` 等。
+  - 在底部按钮区添加“分析角色变化”独立按钮，允许手动触发。
+
+### 6.3 新组件 `CharacterStatusSidebar.tsx`
+- 位置：`frontend/src/components/CharacterStatusSidebar.tsx`
+- 功能：
+  - 按角色分组展示最近一次分析结果。
+  - 显示字段：角色名、`newlyKnownInfo`（若为空显示“无”）、`characterChanges`、`characterDetailsAfter`（可折叠展开）。
+  - 使用 Ant Design `Collapse` 或 `Card`。对于 `isAutoCopied=true` 的记录在标题处显示“无变化”标记。
+  - 提供“历史记录”链接，点击后弹出 Modal（本阶段仅展示当前场景的所有记录，后续阶段可拓展）。
+- 属性：
+  ```ts
+  interface CharacterStatusSidebarProps {
+    characterMap: Record<number, CharacterCard>;
+    logs: CharacterChangeLog[];
+    chapterNumber?: number;
+    sectionNumber?: number;
+    isAnalyzing: boolean;
+    onAnalyze?: () => void;
+  }
+  ```
+
+### 6.4 交互反馈
+- 分析中显示 `Spin` 或按钮 loading。
+- API 错误通过 `message.error` 呈现。
+- 当场景缺少 `presentCharacterIds` 时，提示用户回到大纲补充角色信息。
+
+## 7. 安全与权限
+- 所有新接口均要求登录（沿用 `@AuthenticationPrincipal`）。
+- `CharacterChangeLogService` 在写入前调用：
+  - `validateManuscriptAccess(manuscript, userId)`。
+  - 校验 `sceneId` 是否属于稿件关联的大纲（通过 `OutlineScene` -> `OutlineChapter` -> `OutlineCard`）。
+  - 校验 `characterIds` 是否属于同一个故事卡 `storyCardId`，避免越权访问其他故事的角色档案。
+
+## 8. 测试计划
+- **后端单元测试**（`backend/src/test/java`）：
+  - `CharacterChangeLogServiceTest`
+    - 场景：AI 返回有变化 / 无变化 / JSON 缺失字段 / 场景与稿件不匹配抛异常。
+    - 使用 `@MockBean` 模拟 `OpenAiService` 回传 JSON。
+  - `CharacterChangeLogRepositoryTest`
+    - 验证排序与软删除过滤逻辑。
+- **后端集成测试**：
+  - `ManuscriptControllerIT` 新增接口测试，覆盖鉴权、输入校验、返回结构。
+- **前端测试**：
+  - 使用 React Testing Library 对 `CharacterStatusSidebar` 编写快照与交互测试。
+  - 为 `runCharacterAnalysis` 添加 mock API 调用测试，确保 state 更新正确。
+- **手动验证**：
+  - 启动前后端，完成“生成章节 -> 分析 -> 查看侧栏”流程。
+
+## 9. 实施步骤拆解
+1. **数据库与实体**：创建表结构、编写实体/仓储、跑一次 `mvn test` 保障编译通过。
+2. **服务层开发**：实现 `CharacterChangeLogService`、AI Prompt 构建与 JSON 解析。
+3. **控制器与 DTO**：新增请求/响应对象与 REST 接口，补充权限校验与异常处理。
+4. **前端基础能力**：扩展类型与 API 方法，调整 `ManuscriptWriter` 状态管理。
+5. **UI 组件**：实现 `CharacterStatusSidebar`、修改布局、打通分析流程。
+6. **联调与测试**：补充单元/集成测试、跑端到端验证，更新文档/README 中的使用说明（如必要）。
+7. **验收与回归**：确认旧流程（生成/保存稿件）保持可用，检查软删除与历史查询准确性。
+
+完成以上步骤后，系统即可在每个章节生成/保存后自动得到角色状态追踪数据，为后续阶段提供可靠的数据积累。

--- a/doc/02-dynamic-relationship-mapping.md
+++ b/doc/02-dynamic-relationship-mapping.md
@@ -1,0 +1,252 @@
+# 阶段二子任务设计：关系演化图谱与可视化
+
+## 1. 背景与目标
+- **业务目标**：在角色状态追踪的基础上，记录并可视化角色之间的关系变化，帮助作者掌握人物之间的张力演化。
+- **问题现状**：阶段一虽已积累角色状态，但缺少角色关系的结构化数据，作者无法快速了解人物关系的波动或冲突点。
+- **阶段定位**：在延用阶段一数据模型的同时，扩展数据结构、AI Prompt、前端展示与分析能力。
+
+## 2. 涉及系统与依赖
+| 层级 | 模块 | 本阶段新增/修改点 |
+| --- | --- | --- |
+| 数据层 | `character_change_logs` | 新增 `relationship_changes` JSON 字段及索引 |
+| 后端 | `CharacterChangeLog`、`CharacterChangeLogService` | 扩展实体、解析关系变化、增加图谱数据聚合服务 |
+| 后端 API | `ManuscriptController` | 扩展原分析接口返回关系变化，新增关系图谱查询接口 |
+| AI 服务 | `OpenAiService` | Prompt 增加关系分析需求，输出 JSON 包含 `relationship_changes` |
+| 前端 | `types.ts`、`ManuscriptWriter`、`CharacterStatusSidebar`、新增 `RelationshipGraphModal` | 展示关系变化、调用新接口、可视化关系网络 |
+| 依赖 | 前端新增 `echarts` + `echarts-for-react`（或同级可视化库） | 支撑关系图绘制 |
+
+## 3. 数据库与实体扩展
+### 3.1 数据库字段
+- 在 `backend/src/database.sql` 中为 `character_change_logs` 增加字段：
+  ```sql
+  ALTER TABLE `character_change_logs`
+    ADD COLUMN `relationship_changes` JSON NULL AFTER `is_auto_copied`;
+  ```
+- 索引建议：
+  - `IDX_ccl_relationship_source` (`manuscript_id`, `character_id`, `deleted_at`)
+  - 可选：在 JSON 中存储 `target_character_id`，使用虚拟列+索引（MySQL 8.0 支持），后续若查询性能不足再引入。
+
+### 3.2 JPA 实体调整
+- `CharacterChangeLog` 新增字段：
+  ```java
+  @Type(JsonType.class)
+  @Column(name = "relationship_changes", columnDefinition = "JSON")
+  private List<RelationshipChange> relationshipChanges;
+  ```
+- `RelationshipChange` 值对象（可创建为静态内部类或 `backend/src/main/java/com/example/ainovel/model/value` 下独立类）：
+  ```java
+  @Data
+  public class RelationshipChange {
+      private Long targetCharacterId;
+      private String previousRelationship;
+      private String currentRelationship;
+      private String changeReason;
+  }
+  ```
+- `JsonType` 依赖来自 `hypersistence-utils`（`pom.xml` 已引入）。
+- 在实体的 `copyFrom` 方法中同时复制上一条的 `relationshipChanges`，便于 `no_change` 分支维持关系状态。
+
+### 3.3 DTO 更新
+- `CharacterChangeLogResponse` 增加 `List<RelationshipChangeDto> relationshipChanges`。
+- 新增 DTO `RelationshipChangeDto`（与实体值对象字段一致）用于序列化。
+
+## 4. 后端服务与 API 扩展
+### 4.1 AI 请求上下文扩展
+- 在 `CharacterChangeLogService` 中构建关系上下文：
+  - 对于当前 `characterId`，查询上一条日志的 `relationshipChanges`，并折算成 “当前已知关系快照”。
+  - 组装成 `Map<Long, RelationshipSnapshot>`：`targetId -> {currentRelationship, lastChangeReason, lastUpdateChapter}`。
+  - 在 Prompt 中追加：
+    ```
+    【角色现有关系】
+    {{#each relationshipSnapshot}}
+    - 与 {{targetName}}：当前关系={{currentRelationship}}；最近更新章节={{chapter}}；备注={{reason}}
+    {{/each}}
+    【本节其他角色】
+    {{list of other characters with synopsis}}
+    额外任务：判断与每位出场角色的关系是否发生变化，若变化请写入 relationship_changes 数组。
+    relationship_changes 为数组，每个元素包含 target_character_id, previous_relationship, current_relationship, change_reason。
+    若无变化返回 []。
+    ```
+- 需要向 AI 提供目标角色姓名，故在服务中将 `characterId -> CharacterCard` 映射缓存，避免重复查询。
+
+### 4.2 解析与持久化
+- 在解析 JSON 时新增对 `relationship_changes` 字段的处理：
+  - 若字段缺失，默认 `Collections.emptyList()`。
+  - 校验 `target_character_id` 是否在本节出场角色名单内；若不在则忽略或记录警告日志。
+  - 对每个 `RelationshipChange` 设置 `targetCharacterId` 等字段并保存。
+
+### 4.3 API 调整
+- `POST /api/manuscripts/{manuscriptId}/sections/analyze-character-changes`
+  - Response JSON 增加 `relationshipChanges`。
+- 新增 `GET /api/manuscripts/{manuscriptId}/relationships/graph`
+  - 可选查询参数：`?outlineId=xxx`（默认为稿件关联的大纲）、`?chapterStart=...&chapterEnd=...` 用于筛选范围。
+  - 返回结构：
+    ```json
+    {
+      "nodes": [
+        { "id": 101, "name": "李寻欢" },
+        ...
+      ],
+      "edges": [
+        {
+          "sourceId": 101,
+          "targetId": 102,
+          "latestRelationship": "盟友",
+          "latestChangeLogId": 555,
+          "history": [
+            {
+              "logId": 555,
+              "chapterNumber": 1,
+              "sectionNumber": 3,
+              "previousRelationship": "朋友",
+              "currentRelationship": "盟友",
+              "changeReason": "共同破案",
+              "timestamp": "2025-07-20T12:00:00"
+            },
+            ...
+          ]
+        }
+      ]
+    }
+    ```
+  - Graph 数据由 `CharacterChangeLogService` 新增方法 `buildRelationshipGraph(Long manuscriptId, Long userId, RelationshipGraphQuery query)` 提供。
+
+### 4.4 服务实现要点
+- `buildRelationshipGraph` 步骤：
+  1. 加载稿件下的所有角色卡（`CharacterCardRepository.findByStoryCardId`）。
+  2. 查询 `character_change_logs` 中未删除的记录，按 `createdAt` 及章节顺序排序。
+  3. 遍历日志，将 `relationshipChanges` 展开到 `Map<Pair<Long, Long>, List<HistoryEntry>>`，`Pair` 需规范化（小 ID 在前）以避免重复。
+  4. 生成节点集合（所有涉及角色）。
+  5. 为每条边计算最新关系（history 最后一条 `currentRelationship`）。
+
+## 5. AI Prompt 扩展
+- 在阶段一 Prompt 基础上追加：
+  ```
+  4. 判断该角色与本节出场的其他角色关系是否发生变化。
+  5. 输出 relationship_changes 数组，每个对象包含：
+     - target_character_id: number（请根据提供的角色列表返回 ID）
+     - previous_relationship: string（若无记录请写 "未知"）
+     - current_relationship: string
+     - change_reason: string（描述导致关系变化的关键事件）
+  输出示例：
+  {
+    "newly_known_info": "...",
+    "character_changes": "...",
+    "character_details_after": "...",
+    "relationship_changes": [
+      {
+        "target_character_id": 102,
+        "previous_relationship": "盟友",
+        "current_relationship": "敌人",
+        "change_reason": "因误解而反目"
+      }
+    ],
+    "no_change": false
+  }
+  ```
+- 追加输入：`allCharactersInScene`，包含 `{id, name, synopsis}`。
+- 对于 AI 无法识别的角色（ID 未匹配），后端记录 warning 并跳过，以免破坏数据质量。
+
+## 6. 前端设计与可视化
+### 6.1 类型与 API 扩展
+- `types.ts`：
+  ```ts
+  export interface RelationshipChange {
+    targetCharacterId: number;
+    previousRelationship: string;
+    currentRelationship: string;
+    changeReason: string;
+  }
+
+  export interface CharacterChangeLog {
+    // 阶段一字段...
+    relationshipChanges?: RelationshipChange[];
+  }
+
+  export interface RelationshipGraphNode {
+    id: number;
+    name: string;
+  }
+
+  export interface RelationshipGraphEdge {
+    sourceId: number;
+    targetId: number;
+    latestRelationship: string;
+    latestChangeLogId: number;
+    history: Array<{
+      logId: number;
+      chapterNumber: number;
+      sectionNumber: number;
+      previousRelationship: string;
+      currentRelationship: string;
+      changeReason: string;
+      timestamp: string;
+    }>;
+  }
+
+  export interface RelationshipGraphResponse {
+    nodes: RelationshipGraphNode[];
+    edges: RelationshipGraphEdge[];
+  }
+  ```
+- `services/api.ts` 新增：
+  - `fetchRelationshipGraph(manuscriptId: number, params?: GraphQueryParams): Promise<RelationshipGraphResponse>`。
+  - `GraphQueryParams` 包含章节范围、是否仅显示最新关系等选项。
+
+### 6.2 `CharacterStatusSidebar` 更新
+- 在角色卡片中增加“关系变化”区域：
+  - 若 `relationshipChanges` 非空，使用列表展示 `targetName -> 变化描述`。
+  - 可使用 Tag 表示新增/恶化/改善（根据 `previousRelationship` 与 `currentRelationship` 对比）。
+- 增加“查看关系图谱”按钮，触发 `RelationshipGraphModal`。
+
+### 6.3 新组件 `RelationshipGraphModal.tsx`
+- 结构：
+  - `Modal` + `Tabs`，一个 Tab 显示图谱，另一个 Tab 显示时间轴列表。
+  - 图谱：使用 `echarts` Force Graph，节点显示角色名，边显示最新关系，可根据历史染色。
+  - 时间轴：`Timeline` 或 `Table` 展示所有关系变化记录，允许按角色筛选。
+- 交互：
+  - Modal 打开时调用 `fetchRelationshipGraph`。
+  - 提供章节范围筛选（`Slider` 或 `Select`）。
+  - 点击图谱边可在右侧显示该关系的历史详情。
+- 依赖：在 `package.json` 增加
+  ```json
+  "echarts": "^5.x",
+  "echarts-for-react": "^3.x"
+  ```
+  并在 `vite.config.ts` 确保按需引入。
+
+### 6.4 `ManuscriptWriter` 交互
+- 维持阶段一逻辑，同时：
+  - 将 `characterChangeLogs[sceneId]` 传入侧边栏，侧边栏负责展示关系变化。
+  - 将 `selectedManuscript.id` 作为 prop 传给侧边栏，便于其触发图谱弹窗时调用接口。
+
+## 7. 权限与性能考量
+- 所有新数据均基于 `manuscriptId` + `userId` 权限校验，与阶段一一致。
+- 图谱接口需做分页/限量策略：
+  - 默认返回前 500 条关系变化；超过时要求前端带筛选条件。
+  - 可在查询参数中提供 `limit`、`order`，后端使用 `PageRequest` 控制。
+- JSON 列存储注意 MySQL 版本兼容；若测试环境为 5.7 需降级为 `LONGTEXT` 存储字符串 JSON 并手动序列化。
+
+## 8. 测试计划
+- **后端单元测试**：
+  - `CharacterChangeLogServiceRelationshipTest`：覆盖 AI 返回关系变化、关系为空、目标角色不匹配等场景。
+  - `RelationshipGraphServiceTest`：验证图谱聚合逻辑、章节筛选功能。
+- **后端集成测试**：
+  - `ManuscriptControllerIT` 中新增关系图谱接口测试，验证鉴权与返回结构。
+- **前端测试**：
+  - `CharacterStatusSidebar` 对关系变化的渲染测试。
+  - `RelationshipGraphModal` 使用 mocked API 验证加载、筛选、渲染（可通过 `@testing-library/react` + `jest`）。
+- **性能测试**（可选）：
+  - 构造 1k+ 条关系变动数据，验证接口响应时间与前端渲染表现。
+
+## 9. 实施步骤
+1. **数据库升级**：新增 JSON 字段，更新实体与仓储，编译验证。
+2. **服务层改造**：扩展 `CharacterChangeLogService`，实现关系上下文收集、AI Prompt 扩展、JSON 解析。
+3. **图谱聚合能力**：实现 `buildRelationshipGraph` 方法及 DTO。
+4. **API 与 Controller**：扩展原分析接口返回字段、新增图谱查询接口。
+5. **前端类型与 API**：同步更新类型定义、封装新接口。
+6. **UI 开发**：更新 `CharacterStatusSidebar`，实现 `RelationshipGraphModal`，引入可视化库。
+7. **联调测试**：补充单元/集成测试，运行 `npm test` / `npm run lint`（如有），人工验证交互。
+8. **文档与回归**：更新用户手册、在 README 中说明关系图谱功能，并回归阶段一核心流程。
+
+完成后，用户即可在写作过程中查看每节角色间关系的即时变化，并通过关系图谱回顾故事中人物关系的动态演进。

--- a/doc/03-memory-driven-dialogue.md
+++ b/doc/03-memory-driven-dialogue.md
@@ -1,0 +1,214 @@
+# 阶段三子任务设计：记忆驱动的对话生成
+
+## 1. 背景与目标
+- **目标**：利用阶段一、二积累的角色“记忆”（`newly_known_info`、`character_changes`、关系演化等），让 AI 生成更贴合角色经历与个性的对话。
+- **价值**：提升 AI 对话的一致性，避免角色性格和信息前后矛盾，帮助作者快速产出符合人物弧光的对白。
+- **范围**：新增后端对话生成服务、API 与前端交互。对现有日志数据结构不做破坏性变更。
+
+## 2. 现状分析
+- 角色记忆来源：`character_change_logs` 中 `newly_known_info` 与 `character_changes` 字段。
+- 角色基础设定：`character_cards`（`synopsis`、`details`、`relationships`）。
+- 场景上下文：`outline_scenes`（梗概）与 `manuscript_sections`（正文）。
+- 用户 API Key 管理：`SettingsService` 已支持 per-user 模型/endpoint 配置，可复用。
+
+## 3. 后端设计
+### 3.1 新服务 `AiDialogueService`
+- 位置：`backend/src/main/java/com/example/ainovel/service/AiDialogueService.java`。
+- 依赖：`OpenAiService`、`CharacterChangeLogRepository`、`CharacterCardRepository`、`ManuscriptRepository`、`ManuscriptSectionRepository`、`OutlineSceneRepository`、`SettingsService`。
+- 核心方法：
+  ```java
+  public DialogueResponse generateDialogue(Long manuscriptId, DialogueRequest request, Long userId);
+  ```
+- 主要步骤：
+  1. **校验权限**：确认 `manuscriptId` 属于当前用户；确认 `characterId` 属于稿件对应故事卡。
+  2. **收集角色档案**：读取 `CharacterCard` 的 `name`、`synopsis`、`details`、`relationships`。
+  3. **提取关键记忆**：
+     - 调用 `CharacterChangeLogRepository.findByCharacter_IdAndManuscript_IdAndDeletedAtIsNullOrderByChapterNumberDescSectionNumberDesc`。
+     - 过滤掉 `newly_known_info`、`character_changes` 均为空的记录。
+     - 取最近 N 条（默认 5 条，可配置），并生成摘要：
+       ```
+       第1章第3节：获知“梅花盗真实身份”。状态变化：怀疑转为信任。
+       ```
+     - 如数据量大，可引入简易加权：优先包含被标记为 `isTurningPoint`（阶段四字段，预留）。
+  4. **构建场景上下文**：
+     - 若 `request` 提供 `sceneId`，读取对应 `OutlineScene` 梗概及 `ManuscriptSection` 最新正文；否则使用 `currentSceneDescription`。
+     - 将用户输入的 `dialogueTopic` 作为额外指令。
+  5. **组装 Prompt**（详见 4.1）。
+  6. **调用 AI**：使用 `openAiService.generate(prompt, apiKey, baseUrl, model)`，默认期望纯文本输出。
+  7. **返回结果**：封装为 `DialogueResponse`，包含 `dialogue` 文本、`usedMemories` 列表、`characterName` 等辅助信息。
+
+### 3.2 DTO 定义
+- `DialogueRequest`（放置在 `backend/src/main/java/com/example/ainovel/dto`）：
+  ```java
+  public class DialogueRequest {
+      private Long manuscriptId;
+      private Long characterId;
+      private Long sceneId; // 可选，用于自动填充场景上下文
+      private String currentSceneDescription; // sceneId 缺失时必填
+      private String dialogueTopic; // 可选
+      private Integer memoryLimit; // 可选，默认 5
+      private boolean includeRelationships; // 默认 true
+  }
+  ```
+- `DialogueResponse`：
+  ```java
+  public class DialogueResponse {
+      private String dialogue;
+      private String characterName;
+      private List<String> usedMemories; // 输出给前端展示
+  }
+  ```
+
+### 3.3 控制器
+- 新增 `AiController` 或在现有 `ManuscriptController` 中添加端点：
+  ```java
+  @PostMapping("/ai/dialogue")
+  public ResponseEntity<DialogueResponse> generateDialogue(@RequestBody DialogueRequest request,
+                                                            @AuthenticationPrincipal User user) {
+      return ResponseEntity.ok(aiDialogueService.generateDialogue(request.getManuscriptId(), request, user.getId()));
+  }
+  ```
+- `DialogueRequest` 中需包含 `manuscriptId`，以便校验。
+- 响应错误：
+  - 400：缺少必要字段（如 `characterId`、`manuscriptId`、`sceneId` 与 `currentSceneDescription` 二者皆空）。
+  - 403：角色或稿件不属于当前用户。
+  - 502：AI 返回异常或解析失败。
+
+### 3.4 与现有服务的协作
+- 可在 `CharacterChangeLogService` 中新增方法 `List<CharacterChangeLog> getMemoriesForDialogue(...)`，由 `AiDialogueService` 调用，避免重复查询逻辑。
+- `SettingsService` 提供 `getBaseUrlByUserId`、`getModelNameByUserId`、`getDecryptedApiKeyByUserId`，复用阶段一逻辑。
+
+## 4. AI Prompt 设计
+### 4.1 Prompt 模板
+```
+你是一位了解{{characterName}}经历的小说家。请根据角色设定、记忆与当前情境，写一段符合其语气和立场的对话。
+
+【角色核心设定】
+- 人物简介：{{synopsis}}
+- 详细背景：{{details}}
+- 固有关系：{{relationships}}
+
+【角色近期记忆（按时间倒序）】
+{{#each memories}}
+- 第{{chapter}}章第{{section}}节：{{memory}}
+{{/each}}
+（若无记忆则写“暂无新增记忆”）
+
+【当前情境】
+{{sceneDescription}}
+
+【对话主题】
+{{dialogueTopic 或 “自由发挥”}}
+
+要求：
+1. 对话中必须体现角色对上述记忆的态度或影响。
+2. 保持角色口吻、价值观与既有设定一致。
+3. 若场景涉及其他角色，请结合其与{{characterName}}的最新关系回应（见记忆或关系描述）。
+4. 输出为纯文本对白，可包含对话双方简短动作描写，但避免解释性文字。
+```
+- 若 `includeRelationships=true`，在“角色近期记忆”后追加一节“【重要关系现状】”，列出上一条 `relationshipChanges` 的最新状态。
+- 若 `dialogueTopic` 为空，则替换为“自由发挥”。
+
+### 4.2 Token 控制策略
+- 限制记忆条数（默认 5），可通过 `memoryLimit` 调整。
+- 对每条记忆做简化：`String.format("%s；状态变化：%s", newlyKnownInfo, characterChanges)`，超过 200 字截断。
+- 场景正文若过长（>1200 字），截取最近 600 字，保持 AI 输入简洁。
+
+## 5. 前端设计
+### 5.1 API 封装与类型
+- `types.ts` 新增：
+  ```ts
+  export interface DialogueRequest {
+    manuscriptId: number;
+    characterId: number;
+    sceneId?: number;
+    currentSceneDescription?: string;
+    dialogueTopic?: string;
+    memoryLimit?: number;
+    includeRelationships?: boolean;
+  }
+
+  export interface DialogueResponse {
+    dialogue: string;
+    characterName: string;
+    usedMemories: string[];
+  }
+  ```
+- `services/api.ts` 新增：
+  ```ts
+  export const generateDialogue = (payload: DialogueRequest): Promise<DialogueResponse> =>
+    fetch('/api/v1/ai/dialogue', { method: 'POST', headers: getAuthHeaders(), body: JSON.stringify(payload) })
+      .then(res => handleResponse<DialogueResponse>(res));
+  ```
+
+### 5.2 UI/UX：`GenerateDialogueModal`
+- 新建组件 `frontend/src/components/modals/GenerateDialogueModal.tsx`。
+- Props：
+  ```ts
+  interface GenerateDialogueModalProps {
+    open: boolean;
+    onClose: () => void;
+    manuscriptId: number;
+    characters: CharacterCard[];
+    defaultScene?: Scene;
+    onInsertToEditor?: (dialogue: string) => void;
+  }
+  ```
+- Modal 内容：
+  - 角色选择（`Select`），默认选中当前侧边栏正在查看的角色。
+  - 场景描述：
+    - 若有 `defaultScene`，展示梗概并允许编辑补充。
+    - 提供 `Include latest manuscript content` 复选框，自动填充 `currentSceneDescription` 为梗概 + 正文片段。
+  - 对话主题输入框（可选）。
+  - 记忆条数滑条（1-10，默认 5）。
+  - “生成对话”按钮，点击后调用 `generateDialogue`，显示 loading。
+- 结果展示：
+  - 显示生成文本（可复制）。
+  - “插入到正文光标处”按钮，调用 `onInsertToEditor`。
+  - 展示 `usedMemories` 列表，帮助作者理解 AI 依据。
+
+### 5.3 `ManuscriptWriter` 集成
+- 在正文编辑区域上方工具栏加入按钮：“🗣️ AI 生成对话”。
+- 维护状态 `isDialogueModalOpen`。
+- 打开 Modal 时传入：
+  - `manuscriptId = selectedManuscript.id`
+  - `characters = characterCards`（阶段一加载的角色数据）
+  - `defaultScene = selectedScene`
+  - `onInsertToEditor` 实现为在当前光标处插入文本（可借助 `TextArea` 的 `setRangeText`）。
+
+### 5.4 错误处理
+- 若 API 返回 400/403，弹出错误提示并保留 Modal。
+- 若生成内容为空，提示用户调整主题或补充场景描述。
+
+## 6. 安全与权限
+- `AiDialogueService` 必须复用 `validateManuscriptAccess`。
+- 角色校验：
+  - 通过 `CharacterCard.getStoryCard().getId()` 与 `Manuscript.getOutlineCard().getStoryCard().getId()` 对比。
+- 记录审计日志（可选）：生成请求参数、响应长度，以便后续排查。
+
+## 7. 测试计划
+- **后端单元测试**：
+  - `AiDialogueServiceTest`
+    - 无记忆时生成 Prompt、记忆存在时排序、`memoryLimit` 生效。
+    - 角色不属于稿件、场景不匹配等异常。
+    - 模拟 `OpenAiService` 返回字符串，验证 Response 封装。
+- **后端集成测试**：
+  - `AiControllerIT`：登录用户请求生成对话，校验鉴权与返回体。
+- **前端测试**：
+  - `GenerateDialogueModal`：
+    - 表单校验（角色必选、场景描述或 sceneId 至少一个）。
+    - Mock API 成功/失败流程。
+    - `onInsertToEditor` 被调用。
+- **手动测试**：
+  - 选择带有多条记忆的角色，验证生成文本包含记忆点。
+  - 切换记忆条数、主题，观察输出差异。
+
+## 8. 实施步骤
+1. **后端基础**：创建 DTO、服务、控制器；完善权限校验与 Prompt 构建；编写单元测试。
+2. **前端 API 与类型**：更新 `types.ts`、`services/api.ts`，确认 TS 类型编译通过。
+3. **Modal 组件开发**：实现 UI、表单校验、调用逻辑，与 `ManuscriptWriter` 打通。
+4. **联调**：前后端集成测试，确保生成结果可插入正文。
+5. **文档更新**：在 `doc/user_manual.md` 或 README 中新增使用说明。
+6. **验收与回归**：回归阶段一/二功能（状态追踪、关系图谱）确保无回归。
+
+完成后，作者可在写作时一键生成符合角色记忆的对白，大幅提升创作效率与角色一致性。

--- a/doc/04-turning-point-flagging.md
+++ b/doc/04-turning-point-flagging.md
@@ -1,0 +1,149 @@
+# 阶段四子任务设计：角色关键转折点标记
+
+## 1. 背景与目标
+- **目标**：自动识别对角色成长影响重大的情节，并在 UI 中突出展示，帮助作者快速回顾角色弧光。
+- **依赖**：基于阶段一、二已存储的角色状态与关系数据，阶段三产生的记忆摘要也将引用这些标记。
+- **成果**：
+  - 数据层新增 `is_turning_point` 标记。
+  - 后端扩展分析逻辑和查询接口。
+  - 前端突出显示转折点并提供“成长路径”时间轴视图。
+
+## 2. 数据库与实体变更
+### 2.1 数据库结构
+- 在 `backend/src/database.sql` 中为 `character_change_logs` 增加字段：
+  ```sql
+  ALTER TABLE `character_change_logs`
+    ADD COLUMN `is_turning_point` BOOLEAN NOT NULL DEFAULT FALSE AFTER `relationship_changes`;
+  ```
+- 索引：
+  - `IDX_ccl_turning_points` (`manuscript_id`, `character_id`, `is_turning_point`, `deleted_at`) 用于高效查询某角色的关键节点。
+
+### 2.2 实体调整
+- `CharacterChangeLog` 新增属性：
+  ```java
+  @Column(name = "is_turning_point", nullable = false)
+  private boolean isTurningPoint = false;
+  ```
+- `copyFrom` 方法在复制上一条记录时默认 `isTurningPoint = false`（无变化时不自动标记）。
+- DTO `CharacterChangeLogResponse` 增加 `isTurningPoint` 字段。
+
+## 3. 后端逻辑扩展
+### 3.1 AI 结果解析
+- 在 `CharacterChangeLogService.analyzeAndPersist` 中解析 AI JSON：
+  - 若存在布尔字段 `is_turning_point`，写入实体。
+  - 若缺失则默认 `false` 并记录 warning 日志。
+- 当 `no_change = true` 时，强制 `isTurningPoint = false`。
+
+### 3.2 Prompt 扩展
+- 在阶段一/二 Prompt 基础上追加指令：
+  ```
+  6. 请判断本节对角色是否构成“关键转折点”，标准包括但不限于：
+     - 角色信念或价值观发生重大转变；
+     - 与重要角色的关系出现不可逆的改变；
+     - 影响角色命运的重大事件（濒死、觉醒、背叛等）；
+     - 触发后续剧情核心冲突的决定。
+     如果符合，请将 is_turning_point 设为 true，并在 character_changes 中明确说明转折原因。
+  输出示例：
+  {
+    ...,
+    "is_turning_point": true
+  }
+  ```
+- 在 AI 输入部分补充提醒：若判断为转折点需在 `character_changes` 中给出理由，方便前端展示。
+
+### 3.3 查询接口
+- 新增服务方法：
+  ```java
+  public List<CharacterChangeLog> getTurningPoints(Long manuscriptId, Long characterId, Long userId);
+  ```
+- 新增 API：
+  - `GET /api/manuscripts/{manuscriptId}/characters/{characterId}/turning-points`
+    - 返回排序后的转折点列表（按章节、节、创建时间）。
+    - 响应字段：`chapterNumber`、`sectionNumber`、`characterChanges`、`relationshipChanges`、`createdAt`、`logId`。
+- 在 `CharacterChangeLogService` 中实现查询逻辑，复用仓储方法 `findByCharacter_IdAndManuscript_IdAndDeletedAtIsNullOrderByChapterNumberAscSectionNumberAsc` 并过滤 `isTurningPoint=true`。
+
+### 3.4 与其他模块协作
+- 阶段三对话生成：在选择记忆时优先包含转折点记录（若存在）。可在 `getMemoriesForDialogue` 中增加 `boolean prioritizeTurningPoints` 参数。
+- 关系图谱：当转折点涉及关系变化时，可在前端图谱中高亮对应边（扩展功能，非必须）。
+
+## 4. 前端改动
+### 4.1 `CharacterStatusSidebar`
+- 对 `isTurningPoint=true` 的记录：
+  - 在卡片标题旁显示星标或醒目标签（如 `Tag` + “转折点”）。
+  - `characterChanges` 文案高亮显示。
+- 新增“查看成长路径”按钮（在角色面板顶部），点击后打开新组件。
+
+### 4.2 新组件 `CharacterGrowthPath.tsx`
+- 位置：`frontend/src/components/CharacterGrowthPath.tsx`。
+- Props：
+  ```ts
+  interface CharacterGrowthPathProps {
+    visible: boolean;
+    onClose: () => void;
+    manuscriptId: number;
+    character: CharacterCard;
+  }
+  ```
+- 功能：
+  - 弹窗（`Drawer` 或 `Modal`），展示该角色的所有转折点，按时间轴排列。
+  - 每个节点显示：章节/小节、发生的变化、关系变化摘要、创建时间。
+  - 支持筛选：按章节范围、按关键词搜索。
+  - “跳转到章节”按钮：调用父级回调，在 `ManuscriptWriter` 中定位相应场景。
+- 数据来源：在打开时调用 `GET /api/manuscripts/{id}/characters/{characterId}/turning-points`。
+- UI 建议：使用 Ant Design `Timeline` 或自定义竖向步骤条。
+
+### 4.3 `ManuscriptWriter` 集成
+- 将 `selectedCharacterForSidebar` 状态下沉至 `CharacterStatusSidebar`，当用户点击成长路径时传递角色对象。
+- 通过回调 `onJumpToScene(sceneId)` 使时间轴与左侧大纲联动。
+
+### 4.4 类型与 API
+- `types.ts` 扩展：
+  ```ts
+  export interface CharacterChangeLog {
+    ...
+    isTurningPoint: boolean;
+  }
+
+  export interface TurningPointEntry {
+    id: number;
+    chapterNumber: number;
+    sectionNumber: number;
+    characterChanges: string;
+    relationshipChanges?: RelationshipChange[];
+    createdAt: string;
+    sceneId: number;
+  }
+  ```
+- `services/api.ts` 新增：
+  ```ts
+  export const fetchTurningPoints = (manuscriptId: number, characterId: number): Promise<TurningPointEntry[]> =>
+    fetch(`/api/v1/manuscripts/${manuscriptId}/characters/${characterId}/turning-points`, { headers: getAuthHeaders() })
+      .then(res => handleResponse<TurningPointEntry[]>(res));
+  ```
+
+## 5. 安全与一致性
+- 权限检查与阶段一一致，所有查询需校验 `manuscriptId` 与 `userId`。
+- AI 返回转折点时的可信度：
+  - 可在日志中记录 AI 原始响应，便于人工审查。
+  - 预留手动调整能力（后续扩展）：允许用户在 UI 中手动设/取消转折点（本阶段不实现，但实体设计已支持手动更新 `is_turning_point`）。
+
+## 6. 测试计划
+- **后端单元测试**：
+  - `CharacterChangeLogServiceTurningPointTest`：验证 `is_turning_point` 解析、`no_change` 分支强制为 false、查询接口返回顺序正确。
+- **后端集成测试**：
+  - `ManuscriptControllerIT`：新增 GET 转折点接口鉴权、返回字段校验。
+- **前端测试**：
+  - `CharacterStatusSidebar` 渲染星标测试。
+  - `CharacterGrowthPath` 组件交互测试（加载、筛选、跳转）。
+- **人工验证**：
+  - 构造包含多个转折点的场景，确认时间轴排序正确且与章节联动。
+
+## 7. 实施步骤
+1. **数据库与实体**：添加 `is_turning_point` 字段，更新实体、仓储与 DTO。
+2. **AI 逻辑**：扩展 Prompt 与解析逻辑，单元测试覆盖布尔标记。
+3. **查询接口**：实现 `getTurningPoints` 服务及 REST API。
+4. **前端改造**：更新类型、API 封装、侧边栏高亮、成长路径组件。
+5. **联调与测试**：运行 `mvn test`、`npm test`，手动验证 UI 与数据一致。
+6. **文档更新**：在用户手册中新增转折点功能说明，示意如何使用成长路径视图。
+
+完成后，作者可以快速识别角色的关键成长节点，并通过时间轴回顾人物弧光，实现更高效的故事打磨。


### PR DESCRIPTION
## Summary
- add 01-character-status-tracking.md describing the foundational logging workflow
- add 02-dynamic-relationship-mapping.md defining relationship analytics and visualization plan
- add 03-memory-driven-dialogue.md specifying the dialogue generation workflow based on character memory
- add 04-turning-point-flagging.md detailing turning point detection and UI integration

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ca9af59e64833092ff85c8e09b2ac8