### PR TITLE
Implement character change tracking pipeline

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -93,6 +93,11 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/database.sql
+++ b/backend/src/database.sql
@@ -182,3 +182,32 @@ ADD COLUMN `actions_in_scene` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai
 -- 2) Drop deprecated llm_provider column
 ALTER TABLE `user_settings` ADD COLUMN `base_url` varchar(255) NULL DEFAULT NULL AFTER `custom_prompt`;
 ALTER TABLE `user_settings` DROP COLUMN `llm_provider`;
+
+-- ----------------------------
+-- Table structure for character_change_logs
+-- ----------------------------
+DROP TABLE IF EXISTS `character_change_logs`;
+CREATE TABLE `character_change_logs`  (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `character_id` bigint NOT NULL,
+  `manuscript_id` bigint NOT NULL,
+  `scene_id` bigint NOT NULL,
+  `outline_id` bigint NOT NULL,
+  `chapter_number` int NOT NULL,
+  `section_number` int NOT NULL,
+  `newly_known_info` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL,
+  `character_changes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL,
+  `character_details_after` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+  `is_auto_copied` bit(1) NOT NULL DEFAULT b'0',
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `deleted_at` datetime NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE,
+  INDEX `idx_ccl_character`(`character_id`, `manuscript_id`) USING BTREE,
+  INDEX `idx_ccl_scene`(`manuscript_id`, `scene_id`, `chapter_number`, `section_number`) USING BTREE,
+  INDEX `idx_ccl_turning`(`manuscript_id`, `character_id`, `deleted_at`) USING BTREE,
+  CONSTRAINT `fk_ccl_character` FOREIGN KEY (`character_id`) REFERENCES `character_cards` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT `fk_ccl_manuscript` FOREIGN KEY (`manuscript_id`) REFERENCES `manuscripts` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT `fk_ccl_outline` FOREIGN KEY (`outline_id`) REFERENCES `outline_cards` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT `fk_ccl_scene` FOREIGN KEY (`scene_id`) REFERENCES `outline_scenes` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci ROW_FORMAT = Dynamic;

--- a/backend/src/main/java/com/example/ainovel/controller/ManuscriptController.java
+++ b/backend/src/main/java/com/example/ainovel/controller/ManuscriptController.java
@@ -1,5 +1,7 @@
 package com.example.ainovel.controller;
 
+import com.example.ainovel.dto.AnalyzeCharacterChangesRequest;
+import com.example.ainovel.dto.CharacterChangeLogResponse;
 import com.example.ainovel.dto.ManuscriptDto;
 import com.example.ainovel.dto.ManuscriptWithSectionsDto;
 import com.example.ainovel.dto.UpdateSectionRequest;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Controller for handling manuscript-related operations.
@@ -99,5 +102,31 @@ public class ManuscriptController {
     public ResponseEntity<Void> deleteManuscript(@PathVariable Long manuscriptId, @AuthenticationPrincipal User user) {
         manuscriptService.deleteManuscript(manuscriptId, user.getId());
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/manuscripts/{manuscriptId}/sections/analyze-character-changes")
+    public ResponseEntity<List<CharacterChangeLogResponse>> analyzeCharacterChanges(
+            @PathVariable Long manuscriptId,
+            @RequestBody AnalyzeCharacterChangesRequest request,
+            @AuthenticationPrincipal User user) {
+        List<CharacterChangeLogResponse> responses = manuscriptService
+                .analyzeCharacterChanges(manuscriptId, request, user.getId())
+                .stream()
+                .map(CharacterChangeLogResponse::from)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/manuscripts/{manuscriptId}/sections/{sceneId}/character-change-logs")
+    public ResponseEntity<List<CharacterChangeLogResponse>> getCharacterChangeLogs(
+            @PathVariable Long manuscriptId,
+            @PathVariable Long sceneId,
+            @AuthenticationPrincipal User user) {
+        List<CharacterChangeLogResponse> responses = manuscriptService
+                .getCharacterChangeLogs(manuscriptId, sceneId, user.getId())
+                .stream()
+                .map(CharacterChangeLogResponse::from)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
     }
 }

--- a/backend/src/main/java/com/example/ainovel/dto/AnalyzeCharacterChangesRequest.java
+++ b/backend/src/main/java/com/example/ainovel/dto/AnalyzeCharacterChangesRequest.java
@@ -1,0 +1,16 @@
+package com.example.ainovel.dto;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class AnalyzeCharacterChangesRequest {
+    private Long sceneId;
+    private Integer chapterNumber;
+    private Integer sectionNumber;
+    private String sectionContent;
+    private List<Long> characterIds;
+    private Long outlineId;
+}
+

--- a/backend/src/main/java/com/example/ainovel/dto/CharacterChangeLogResponse.java
+++ b/backend/src/main/java/com/example/ainovel/dto/CharacterChangeLogResponse.java
@@ -1,0 +1,35 @@
+package com.example.ainovel.dto;
+
+import java.time.LocalDateTime;
+
+import com.example.ainovel.model.CharacterChangeLog;
+
+import lombok.Data;
+
+@Data
+public class CharacterChangeLogResponse {
+    private Long logId;
+    private Long characterId;
+    private Integer chapterNumber;
+    private Integer sectionNumber;
+    private String newlyKnownInfo;
+    private String characterChanges;
+    private String characterDetailsAfter;
+    private boolean autoCopied;
+    private LocalDateTime createdAt;
+
+    public static CharacterChangeLogResponse from(CharacterChangeLog log) {
+        CharacterChangeLogResponse response = new CharacterChangeLogResponse();
+        response.setLogId(log.getId());
+        response.setCharacterId(log.getCharacter() != null ? log.getCharacter().getId() : null);
+        response.setChapterNumber(log.getChapterNumber());
+        response.setSectionNumber(log.getSectionNumber());
+        response.setNewlyKnownInfo(log.getNewlyKnownInfo());
+        response.setCharacterChanges(log.getCharacterChanges());
+        response.setCharacterDetailsAfter(log.getCharacterDetailsAfter());
+        response.setAutoCopied(Boolean.TRUE.equals(log.getIsAutoCopied()));
+        response.setCreatedAt(log.getCreatedAt());
+        return response;
+    }
+}
+

--- a/backend/src/main/java/com/example/ainovel/exception/BadRequestException.java
+++ b/backend/src/main/java/com/example/ainovel/exception/BadRequestException.java
@@ -1,0 +1,13 @@
+package com.example.ainovel.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+}
+

--- a/backend/src/main/java/com/example/ainovel/model/CharacterChangeLog.java
+++ b/backend/src/main/java/com/example/ainovel/model/CharacterChangeLog.java
@@ -1,0 +1,111 @@
+package com.example.ainovel.model;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.Where;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+/**
+ * Entity that records character state changes for each manuscript section.
+ */
+@Data
+@Entity
+@Table(name = "character_change_logs", indexes = {
+        @Index(name = "idx_ccl_character", columnList = "character_id,manuscript_id"),
+        @Index(name = "idx_ccl_scene", columnList = "manuscript_id,scene_id,chapter_number,section_number"),
+        @Index(name = "idx_ccl_turning", columnList = "manuscript_id,character_id,deleted_at")
+})
+@SQLDelete(sql = "UPDATE character_change_logs SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class CharacterChangeLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "character_id", nullable = false)
+    private CharacterCard character;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manuscript_id", nullable = false)
+    private Manuscript manuscript;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "outline_id", nullable = false)
+    private OutlineCard outline;
+
+    @Column(name = "scene_id", nullable = false)
+    private Long sceneId;
+
+    @Column(name = "chapter_number", nullable = false)
+    private Integer chapterNumber;
+
+    @Column(name = "section_number", nullable = false)
+    private Integer sectionNumber;
+
+    @Column(name = "newly_known_info", columnDefinition = "TEXT")
+    private String newlyKnownInfo;
+
+    @Column(name = "character_changes", columnDefinition = "TEXT")
+    private String characterChanges;
+
+    @Lob
+    @Column(name = "character_details_after", nullable = false, columnDefinition = "LONGTEXT")
+    private String characterDetailsAfter;
+
+    @Column(name = "is_auto_copied", nullable = false)
+    private Boolean isAutoCopied = false;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    /**
+     * Copy the character details from the previous log when no change occurs.
+     *
+     * @param previous the previous log to copy from
+     */
+    public CharacterChangeLog copyFrom(CharacterChangeLog previous) {
+        if (previous == null) {
+            throw new IllegalArgumentException("Previous log must not be null when copying");
+        }
+        this.characterDetailsAfter = previous.getCharacterDetailsAfter();
+        this.isAutoCopied = true;
+        return this;
+    }
+
+    /**
+     * Build a composite key for ordering within a manuscript timeline.
+     *
+     * @return a string combining chapter and section numbers
+     */
+    public String buildTimelineKey() {
+        Integer chapter = this.chapterNumber != null ? this.chapterNumber : 0;
+        Integer section = this.sectionNumber != null ? this.sectionNumber : 0;
+        return String.format("%d-%d", chapter, section);
+    }
+}
+

--- a/backend/src/main/java/com/example/ainovel/repository/CharacterChangeLogRepository.java
+++ b/backend/src/main/java/com/example/ainovel/repository/CharacterChangeLogRepository.java
@@ -1,0 +1,24 @@
+package com.example.ainovel.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.ainovel.model.CharacterChangeLog;
+
+public interface CharacterChangeLogRepository extends JpaRepository<CharacterChangeLog, Long> {
+
+    Optional<CharacterChangeLog> findFirstByCharacter_IdAndManuscript_IdAndDeletedAtIsNullOrderByChapterNumberDescSectionNumberDescCreatedAtDesc(
+            Long characterId,
+            Long manuscriptId);
+
+    List<CharacterChangeLog> findByManuscript_IdAndSceneIdAndDeletedAtIsNullOrderByCharacter_Id(
+            Long manuscriptId,
+            Long sceneId);
+
+    List<CharacterChangeLog> findByCharacter_IdAndManuscript_IdAndDeletedAtIsNullOrderByChapterNumberAscSectionNumberAsc(
+            Long characterId,
+            Long manuscriptId);
+}
+

--- a/backend/src/main/java/com/example/ainovel/service/CharacterChangeLogService.java
+++ b/backend/src/main/java/com/example/ainovel/service/CharacterChangeLogService.java
@@ -1,0 +1,274 @@
+package com.example.ainovel.service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.example.ainovel.dto.AnalyzeCharacterChangesRequest;
+import com.example.ainovel.exception.BadRequestException;
+import com.example.ainovel.exception.ResourceNotFoundException;
+import com.example.ainovel.model.CharacterCard;
+import com.example.ainovel.model.CharacterChangeLog;
+import com.example.ainovel.model.Manuscript;
+import com.example.ainovel.model.OutlineCard;
+import com.example.ainovel.model.OutlineChapter;
+import com.example.ainovel.model.OutlineScene;
+import com.example.ainovel.repository.CharacterCardRepository;
+import com.example.ainovel.repository.CharacterChangeLogRepository;
+import com.example.ainovel.repository.ManuscriptRepository;
+import com.example.ainovel.repository.OutlineSceneRepository;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CharacterChangeLogService {
+
+    private static final Logger log = LoggerFactory.getLogger(CharacterChangeLogService.class);
+
+    private final CharacterChangeLogRepository characterChangeLogRepository;
+    private final ManuscriptRepository manuscriptRepository;
+    private final CharacterCardRepository characterCardRepository;
+    private final OutlineSceneRepository outlineSceneRepository;
+    private final OpenAiService openAiService;
+    private final SettingsService settingsService;
+    private final ManuscriptService manuscriptService;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public List<CharacterChangeLog> analyzeAndPersist(Long manuscriptId, AnalyzeCharacterChangesRequest request, Long userId) {
+        if (request == null) {
+            throw new BadRequestException("请求体不能为空");
+        }
+        if (request.getSceneId() == null) {
+            throw new BadRequestException("sceneId 不能为空");
+        }
+
+        List<Long> characterIds = Optional.ofNullable(request.getCharacterIds()).orElse(Collections.emptyList());
+        if (characterIds.isEmpty()) {
+            throw new BadRequestException("请至少选择一个角色进行分析");
+        }
+
+        Manuscript manuscript = manuscriptRepository.findById(manuscriptId)
+                .orElseThrow(() -> new ResourceNotFoundException("Manuscript not found with id: " + manuscriptId));
+        manuscriptService.validateManuscriptAccess(manuscript, userId);
+
+        OutlineScene scene = outlineSceneRepository.findById(request.getSceneId())
+                .orElseThrow(() -> new ResourceNotFoundException("Scene not found with id: " + request.getSceneId()));
+
+        OutlineChapter chapter = scene.getOutlineChapter();
+        OutlineCard outline = chapter != null ? chapter.getOutlineCard() : null;
+
+        OutlineCard manuscriptOutline = manuscript.getOutlineCard();
+        if (manuscriptOutline == null) {
+            throw new BadRequestException("稿件缺少关联大纲信息");
+        }
+        if (request.getOutlineId() != null && !Objects.equals(request.getOutlineId(), manuscriptOutline.getId())) {
+            throw new BadRequestException("大纲信息与稿件不匹配");
+        }
+        if (outline == null || !Objects.equals(outline.getId(), manuscriptOutline.getId())) {
+            throw new BadRequestException("场景不属于当前稿件所关联的大纲");
+        }
+
+        Long storyCardId = outline.getStoryCard() != null ? outline.getStoryCard().getId() : null;
+
+        Map<Long, CharacterCard> characterMap = new HashMap<>();
+        List<CharacterCard> characters = characterCardRepository.findAllById(characterIds);
+        if (characters.size() != characterIds.size()) {
+            List<Long> foundIds = characters.stream().map(CharacterCard::getId).collect(Collectors.toList());
+            List<Long> missing = characterIds.stream().filter(id -> !foundIds.contains(id)).collect(Collectors.toList());
+            throw new BadRequestException("未找到以下角色: " + missing);
+        }
+        for (CharacterCard character : characters) {
+            if (character.getStoryCard() == null || !Objects.equals(character.getStoryCard().getId(), storyCardId)) {
+                throw new BadRequestException("角色 " + character.getName() + " 不属于当前故事");
+            }
+            characterMap.put(character.getId(), character);
+        }
+
+        String apiKey = settingsService.getDecryptedApiKeyByUserId(userId);
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new BadRequestException("请先在设置中配置有效的 OpenAI API Key");
+        }
+        String baseUrl = settingsService.getBaseUrlByUserId(userId);
+        String model = settingsService.getModelNameByUserId(userId);
+
+        List<CharacterChangeLog> persisted = new ArrayList<>();
+        for (Long characterId : characterIds) {
+            CharacterCard character = characterMap.get(characterId);
+            if (character == null) {
+                continue;
+            }
+
+            Optional<CharacterChangeLog> previousLog = characterChangeLogRepository
+                    .findFirstByCharacter_IdAndManuscript_IdAndDeletedAtIsNullOrderByChapterNumberDescSectionNumberDescCreatedAtDesc(
+                            characterId, manuscriptId);
+
+            String previousDetails = previousLog
+                    .map(CharacterChangeLog::getCharacterDetailsAfter)
+                    .filter(detail -> detail != null && !detail.isBlank())
+                    .orElseGet(() -> defaultIfBlank(character.getDetails(), character.getSynopsis()));
+
+            CharacterAnalysisResult analysis = analyzeWithAi(character, previousDetails, request.getSectionContent(), apiKey,
+                    baseUrl, model);
+
+            CharacterChangeLog logEntry = new CharacterChangeLog();
+            logEntry.setCharacter(character);
+            logEntry.setManuscript(manuscript);
+            logEntry.setOutline(outline);
+            logEntry.setSceneId(scene.getId());
+            logEntry.setChapterNumber(chapter != null ? chapter.getChapterNumber() : request.getChapterNumber());
+            logEntry.setSectionNumber(scene.getSceneNumber() != null ? scene.getSceneNumber() : request.getSectionNumber());
+            logEntry.setNewlyKnownInfo(trimToEmpty(analysis.getNewlyKnownInfo()));
+            logEntry.setCharacterChanges(trimToEmpty(analysis.getCharacterChanges()));
+
+            boolean noChange = Boolean.TRUE.equals(analysis.getNoChange());
+            if (noChange) {
+                logEntry.setNewlyKnownInfo("");
+                logEntry.setCharacterChanges("");
+                if (previousLog.isPresent()) {
+                    logEntry.copyFrom(previousLog.get());
+                } else if (previousDetails != null && !previousDetails.isBlank()) {
+                    logEntry.setCharacterDetailsAfter(previousDetails);
+                    logEntry.setIsAutoCopied(true);
+                } else {
+                    throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+                            "AI 标记角色无变化，但缺少可复制的历史详情");
+                }
+            } else {
+                String detailsAfter = trimToEmpty(analysis.getCharacterDetailsAfter());
+                if (detailsAfter.isBlank()) {
+                    throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+                            "AI 响应缺少 character_details_after 字段");
+                }
+                logEntry.setCharacterDetailsAfter(detailsAfter);
+                logEntry.setIsAutoCopied(false);
+            }
+
+            CharacterChangeLog saved = characterChangeLogRepository.save(logEntry);
+            persisted.add(saved);
+        }
+
+        return persisted;
+    }
+
+    @Transactional(readOnly = true)
+    public List<CharacterChangeLog> getLogsForScene(Long manuscriptId, Long sceneId, Long userId) {
+        Manuscript manuscript = manuscriptRepository.findById(manuscriptId)
+                .orElseThrow(() -> new ResourceNotFoundException("Manuscript not found with id: " + manuscriptId));
+        manuscriptService.validateManuscriptAccess(manuscript, userId);
+
+        OutlineScene scene = outlineSceneRepository.findById(sceneId)
+                .orElseThrow(() -> new ResourceNotFoundException("Scene not found with id: " + sceneId));
+
+        OutlineChapter chapter = scene.getOutlineChapter();
+        OutlineCard outline = chapter != null ? chapter.getOutlineCard() : null;
+        OutlineCard manuscriptOutline = manuscript.getOutlineCard();
+        if (outline == null || manuscriptOutline == null || !Objects.equals(outline.getId(), manuscriptOutline.getId())) {
+            throw new BadRequestException("场景不属于当前稿件所关联的大纲");
+        }
+
+        return characterChangeLogRepository
+                .findByManuscript_IdAndSceneIdAndDeletedAtIsNullOrderByCharacter_Id(manuscriptId, sceneId);
+    }
+
+    private CharacterAnalysisResult analyzeWithAi(CharacterCard character, String previousDetails, String sectionContent,
+            String apiKey, String baseUrl, String model) {
+        String prompt = buildPrompt(character, previousDetails, sectionContent);
+        try {
+            String json = openAiService.generateJson(prompt, apiKey, baseUrl, model);
+            return objectMapper.readValue(json, CharacterAnalysisResult.class);
+        } catch (JsonProcessingException e) {
+            log.error("解析角色 {} 的 AI 响应失败", character.getName(), e);
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "无法解析 AI 响应");
+        } catch (RuntimeException e) {
+            log.error("调用 AI 服务分析角色 {} 时出错", character.getName(), e);
+            throw e;
+        }
+    }
+
+    private String buildPrompt(CharacterCard character, String previousDetails, String sectionContent) {
+        String synopsis = defaultIfBlank(character.getSynopsis(), "无");
+        String baseline = defaultIfBlank(previousDetails, "无");
+        String content = defaultIfBlank(sectionContent, "无");
+        return "你是小说编辑，负责追踪角色状态。请根据提供的信息判断角色是否在本小节发生变化。\n"
+                + "【角色既有设定】\n"
+                + "- 角色名称: " + defaultIfBlank(character.getName(), "未知角色") + "\n"
+                + "- 基础档案: " + synopsis + "\n"
+                + "- 上一次记录的角色详情: " + baseline + "\n"
+                + "【本节正文】\n"
+                + content + "\n"
+                + "任务：\n"
+                + "1. 分析角色在本节新增认知或信息，使用第一人称/第三人称均可。\n"
+                + "2. 总结角色状态（心理、生理、外貌、人际态度等）发生的变化。\n"
+                + "3. 输出本节结束后的最新角色详情，需完整覆盖角色核心设定，允许保留未变化的描述。\n"
+                + "输出格式必须是 JSON\n"
+                + "{\n"
+                + "  \"newly_known_info\": \"string，可为空字符串\",\n"
+                + "  \"character_changes\": \"string，可为空字符串\",\n"
+                + "  \"character_details_after\": \"string\",\n"
+                + "  \"no_change\": true/false\n"
+                + "}\n"
+                + "若确无变化，将 newly_known_info 和 character_changes 置为 \"\"，并将 no_change 设为 true。";
+    }
+
+    private String trimToEmpty(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.trim();
+    }
+
+    private String defaultIfBlank(String value, String fallback) {
+        if (value == null) {
+            return fallback;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? fallback : trimmed;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class CharacterAnalysisResult {
+        @JsonProperty("newly_known_info")
+        private String newlyKnownInfo;
+        @JsonProperty("character_changes")
+        private String characterChanges;
+        @JsonProperty("character_details_after")
+        private String characterDetailsAfter;
+        @JsonProperty("no_change")
+        private Boolean noChange;
+
+        public String getNewlyKnownInfo() {
+            return newlyKnownInfo;
+        }
+
+        public String getCharacterChanges() {
+            return characterChanges;
+        }
+
+        public String getCharacterDetailsAfter() {
+            return characterDetailsAfter;
+        }
+
+        public Boolean getNoChange() {
+            return noChange;
+        }
+    }
+}
+

--- a/backend/src/main/java/com/example/ainovel/service/OpenAiService.java
+++ b/backend/src/main/java/com/example/ainovel/service/OpenAiService.java
@@ -76,6 +76,19 @@ public class OpenAiService extends AbstractAiService {
         }
     }
 
+    public String generateJson(String prompt, String apiKey, String baseUrl, String model) {
+        try {
+            return callOpenAi(prompt, apiKey, baseUrl, model, true);
+        } catch (JsonProcessingException e) {
+            log.error("Error processing JSON for OpenAI structured generation", e);
+            throw new RuntimeException("Failed to process JSON for OpenAI structured generation.", e);
+        }
+    }
+
+    public String generateJson(String prompt, String apiKey) {
+        return generateJson(prompt, apiKey, null, null);
+    }
+
     // Legacy two-arg variant for backward compatibility
     @Override
     @Retryable(value = {RestClientException.class, RuntimeException.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000))

--- a/backend/src/test/java/com/example/ainovel/controller/ManuscriptControllerIT.java
+++ b/backend/src/test/java/com/example/ainovel/controller/ManuscriptControllerIT.java
@@ -1,0 +1,125 @@
+package com.example.ainovel.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.ainovel.dto.AnalyzeCharacterChangesRequest;
+import com.example.ainovel.exception.BadRequestException;
+import com.example.ainovel.model.CharacterCard;
+import com.example.ainovel.model.CharacterChangeLog;
+import com.example.ainovel.model.User;
+import com.example.ainovel.service.ManuscriptService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(controllers = ManuscriptController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ManuscriptControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ManuscriptService manuscriptService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private Authentication authentication;
+
+    @BeforeEach
+    void setUp() {
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("tester");
+        authentication = new UsernamePasswordAuthenticationToken(user, null, List.of());
+    }
+
+    @Test
+    void analyzeCharacterChanges_shouldReturnResponseList() throws Exception {
+        CharacterCard character = new CharacterCard();
+        character.setId(99L);
+        character.setName("角色一");
+
+        CharacterChangeLog log = new CharacterChangeLog();
+        log.setId(5L);
+        log.setCharacter(character);
+        log.setChapterNumber(3);
+        log.setSectionNumber(2);
+        log.setCharacterDetailsAfter("最新详情");
+        log.setNewlyKnownInfo("发现秘密");
+        log.setCharacterChanges("情绪变化");
+        log.setIsAutoCopied(false);
+
+        when(manuscriptService.analyzeCharacterChanges(anyLong(), any(AnalyzeCharacterChangesRequest.class), anyLong()))
+                .thenReturn(List.of(log));
+
+        AnalyzeCharacterChangesRequest request = new AnalyzeCharacterChangesRequest();
+        request.setSceneId(10L);
+        request.setCharacterIds(List.of(99L));
+        request.setSectionContent("正文");
+
+        mockMvc.perform(post("/api/v1/manuscripts/1/sections/analyze-character-changes")
+                        .with(authentication(authentication))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].characterId").value(99L))
+                .andExpect(jsonPath("$[0].characterDetailsAfter").value("最新详情"));
+    }
+
+    @Test
+    void analyzeCharacterChanges_shouldReturnBadRequestWhenServiceThrows() throws Exception {
+        when(manuscriptService.analyzeCharacterChanges(anyLong(), any(AnalyzeCharacterChangesRequest.class), anyLong()))
+                .thenThrow(new BadRequestException("invalid"));
+
+        AnalyzeCharacterChangesRequest request = new AnalyzeCharacterChangesRequest();
+        request.setSceneId(10L);
+        request.setCharacterIds(List.of(1L));
+        request.setSectionContent("正文");
+
+        mockMvc.perform(post("/api/v1/manuscripts/1/sections/analyze-character-changes")
+                        .with(authentication(authentication))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getCharacterChangeLogs_shouldReturnLogs() throws Exception {
+        CharacterCard character = new CharacterCard();
+        character.setId(77L);
+
+        CharacterChangeLog log = new CharacterChangeLog();
+        log.setId(8L);
+        log.setCharacter(character);
+        log.setChapterNumber(1);
+        log.setSectionNumber(1);
+        log.setCharacterDetailsAfter("详情");
+
+        when(manuscriptService.getCharacterChangeLogs(anyLong(), anyLong(), anyLong())).thenReturn(List.of(log));
+
+        mockMvc.perform(get("/api/v1/manuscripts/1/sections/2/character-change-logs")
+                        .with(authentication(authentication)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].logId").value(8L));
+    }
+}
+

--- a/backend/src/test/java/com/example/ainovel/repository/CharacterChangeLogRepositoryTest.java
+++ b/backend/src/test/java/com/example/ainovel/repository/CharacterChangeLogRepositoryTest.java
@@ -1,0 +1,158 @@
+package com.example.ainovel.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import com.example.ainovel.model.CharacterCard;
+import com.example.ainovel.model.CharacterChangeLog;
+import com.example.ainovel.model.Manuscript;
+import com.example.ainovel.model.OutlineCard;
+import com.example.ainovel.model.OutlineChapter;
+import com.example.ainovel.model.OutlineScene;
+import com.example.ainovel.model.StoryCard;
+import com.example.ainovel.model.User;
+
+@DataJpaTest
+class CharacterChangeLogRepositoryTest {
+
+    @Autowired
+    private CharacterChangeLogRepository repository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Manuscript manuscript;
+    private OutlineScene scene;
+    private CharacterCard characterA;
+    private CharacterCard characterB;
+
+    @BeforeEach
+    void init() {
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("tester");
+        user.setEmail("tester@example.com");
+        user.setPassword("pass");
+        entityManager.persist(user);
+
+        StoryCard story = new StoryCard();
+        story.setId(10L);
+        story.setTitle("Story");
+        story.setUser(user);
+        entityManager.persist(story);
+
+        OutlineCard outline = new OutlineCard();
+        outline.setId(20L);
+        outline.setStoryCard(story);
+        outline.setUser(user);
+        outline.setTitle("Outline");
+        entityManager.persist(outline);
+
+        OutlineChapter chapter = new OutlineChapter();
+        chapter.setId(30L);
+        chapter.setOutlineCard(outline);
+        chapter.setChapterNumber(1);
+        entityManager.persist(chapter);
+
+        scene = new OutlineScene();
+        scene.setId(40L);
+        scene.setOutlineChapter(chapter);
+        scene.setSceneNumber(2);
+        entityManager.persist(scene);
+
+        manuscript = new Manuscript();
+        manuscript.setId(50L);
+        manuscript.setOutlineCard(outline);
+        manuscript.setUser(user);
+        manuscript.setTitle("Manuscript");
+        entityManager.persist(manuscript);
+
+        characterA = new CharacterCard();
+        characterA.setId(60L);
+        characterA.setName("角色A");
+        characterA.setStoryCard(story);
+        characterA.setUser(user);
+        entityManager.persist(characterA);
+
+        characterB = new CharacterCard();
+        characterB.setId(61L);
+        characterB.setName("角色B");
+        characterB.setStoryCard(story);
+        characterB.setUser(user);
+        entityManager.persist(characterB);
+    }
+
+    @Test
+    void findByManuscriptAndSceneShouldIgnoreSoftDeleted() {
+        CharacterChangeLog active = createLog(characterA, 1, 1, false);
+        CharacterChangeLog deleted = createLog(characterB, 1, 1, false);
+        deleted.setDeletedAt(LocalDateTime.now());
+        entityManager.persist(active);
+        entityManager.persist(deleted);
+        entityManager.flush();
+
+        List<CharacterChangeLog> logs = repository
+                .findByManuscript_IdAndSceneIdAndDeletedAtIsNullOrderByCharacter_Id(manuscript.getId(), scene.getId());
+
+        assertThat(logs).hasSize(1);
+        assertThat(logs.get(0).getCharacter().getId()).isEqualTo(characterA.getId());
+    }
+
+    @Test
+    void findFirstByCharacterShouldReturnLatestByChapterAndSection() {
+        CharacterChangeLog first = createLog(characterA, 1, 1, false);
+        CharacterChangeLog second = createLog(characterA, 2, 1, false);
+        CharacterChangeLog latest = createLog(characterA, 2, 3, false);
+        entityManager.persist(first);
+        entityManager.persist(second);
+        entityManager.persist(latest);
+        entityManager.flush();
+
+        CharacterChangeLog fetched = repository
+                .findFirstByCharacter_IdAndManuscript_IdAndDeletedAtIsNullOrderByChapterNumberDescSectionNumberDescCreatedAtDesc(
+                        characterA.getId(), manuscript.getId())
+                .orElseThrow();
+
+        assertThat(fetched.getSectionNumber()).isEqualTo(3);
+    }
+
+    @Test
+    void findByCharacterShouldReturnAscendingOrder() {
+        CharacterChangeLog first = createLog(characterB, 1, 3, false);
+        CharacterChangeLog second = createLog(characterB, 1, 1, false);
+        CharacterChangeLog third = createLog(characterB, 2, 1, false);
+        entityManager.persist(first);
+        entityManager.persist(second);
+        entityManager.persist(third);
+        entityManager.flush();
+
+        List<CharacterChangeLog> logs = repository
+                .findByCharacter_IdAndManuscript_IdAndDeletedAtIsNullOrderByChapterNumberAscSectionNumberAsc(
+                        characterB.getId(), manuscript.getId());
+
+        assertThat(logs).extracting(CharacterChangeLog::getSectionNumber)
+                .containsExactly(1, 3, 1);
+    }
+
+    private CharacterChangeLog createLog(CharacterCard character, int chapterNumber, int sectionNumber, boolean autoCopied) {
+        CharacterChangeLog log = new CharacterChangeLog();
+        log.setCharacter(character);
+        log.setManuscript(manuscript);
+        log.setOutline(manuscript.getOutlineCard());
+        log.setSceneId(scene.getId());
+        log.setChapterNumber(chapterNumber);
+        log.setSectionNumber(sectionNumber);
+        log.setCharacterDetailsAfter("详情" + chapterNumber + sectionNumber);
+        log.setIsAutoCopied(autoCopied);
+        return log;
+    }
+}
+

--- a/backend/src/test/java/com/example/ainovel/service/CharacterChangeLogServiceTest.java
+++ b/backend/src/test/java/com/example/ainovel/service/CharacterChangeLogServiceTest.java
@@ -1,0 +1,253 @@
+package com.example.ainovel.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.ainovel.dto.AnalyzeCharacterChangesRequest;
+import com.example.ainovel.exception.BadRequestException;
+import com.example.ainovel.model.CharacterCard;
+import com.example.ainovel.model.CharacterChangeLog;
+import com.example.ainovel.model.Manuscript;
+import com.example.ainovel.model.OutlineCard;
+import com.example.ainovel.model.OutlineChapter;
+import com.example.ainovel.model.OutlineScene;
+import com.example.ainovel.model.StoryCard;
+import com.example.ainovel.model.User;
+import com.example.ainovel.repository.CharacterCardRepository;
+import com.example.ainovel.repository.CharacterChangeLogRepository;
+import com.example.ainovel.repository.ManuscriptRepository;
+import com.example.ainovel.repository.OutlineSceneRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class CharacterChangeLogServiceTest {
+
+    @Mock
+    private CharacterChangeLogRepository characterChangeLogRepository;
+    @Mock
+    private ManuscriptRepository manuscriptRepository;
+    @Mock
+    private CharacterCardRepository characterCardRepository;
+    @Mock
+    private OutlineSceneRepository outlineSceneRepository;
+    @Mock
+    private OpenAiService openAiService;
+    @Mock
+    private SettingsService settingsService;
+    @Mock
+    private ManuscriptService manuscriptService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private CharacterChangeLogService characterChangeLogService;
+
+    private Manuscript manuscript;
+    private OutlineScene outlineScene;
+    private CharacterCard characterCard;
+
+    private static final Long MANUSCRIPT_ID = 100L;
+    private static final Long SCENE_ID = 500L;
+    private static final Long CHARACTER_ID = 900L;
+    private static final Long USER_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        User user = new User();
+        user.setId(USER_ID);
+
+        StoryCard storyCard = new StoryCard();
+        storyCard.setId(200L);
+        storyCard.setUser(user);
+
+        OutlineCard outlineCard = new OutlineCard();
+        outlineCard.setId(300L);
+        outlineCard.setStoryCard(storyCard);
+        outlineCard.setUser(user);
+
+        OutlineChapter chapter = new OutlineChapter();
+        chapter.setId(400L);
+        chapter.setOutlineCard(outlineCard);
+        chapter.setChapterNumber(2);
+
+        outlineScene = new OutlineScene();
+        outlineScene.setId(SCENE_ID);
+        outlineScene.setOutlineChapter(chapter);
+        outlineScene.setSceneNumber(5);
+        outlineScene.setPresentCharacters("[" + CHARACTER_ID + "]");
+
+        manuscript = new Manuscript();
+        manuscript.setId(MANUSCRIPT_ID);
+        manuscript.setOutlineCard(outlineCard);
+        manuscript.setUser(user);
+
+        characterCard = new CharacterCard();
+        characterCard.setId(CHARACTER_ID);
+        characterCard.setStoryCard(storyCard);
+        characterCard.setUser(user);
+        characterCard.setName("林渊");
+        characterCard.setSynopsis("冷静的侦探");
+        characterCard.setDetails("初始详情");
+
+        characterChangeLogService = new CharacterChangeLogService(
+                characterChangeLogRepository,
+                manuscriptRepository,
+                characterCardRepository,
+                outlineSceneRepository,
+                openAiService,
+                settingsService,
+                manuscriptService,
+                objectMapper);
+    }
+
+    @Test
+    void analyzeAndPersist_shouldPersistLogWhenAiReturnsChanges() {
+        AnalyzeCharacterChangesRequest request = new AnalyzeCharacterChangesRequest();
+        request.setSceneId(SCENE_ID);
+        request.setSectionContent("内容");
+        request.setCharacterIds(List.of(CHARACTER_ID));
+
+        when(manuscriptRepository.findById(MANUSCRIPT_ID)).thenReturn(Optional.of(manuscript));
+        doNothing().when(manuscriptService).validateManuscriptAccess(manuscript, USER_ID);
+        when(outlineSceneRepository.findById(SCENE_ID)).thenReturn(Optional.of(outlineScene));
+        when(characterCardRepository.findAllById(request.getCharacterIds())).thenReturn(List.of(characterCard));
+        when(settingsService.getDecryptedApiKeyByUserId(USER_ID)).thenReturn("api-key");
+        when(settingsService.getBaseUrlByUserId(USER_ID)).thenReturn("https://base");
+        when(settingsService.getModelNameByUserId(USER_ID)).thenReturn("gpt-test");
+        when(openAiService.generateJson(any(String.class), eq("api-key"), eq("https://base"), eq("gpt-test")))
+                .thenReturn("{" +
+                        "\"newly_known_info\":\"得知真相\"," +
+                        "\"character_changes\":\"情绪转变\"," +
+                        "\"character_details_after\":\"最新详情\"," +
+                        "\"no_change\":false}" );
+        when(characterChangeLogRepository.findFirstByCharacter_IdAndManuscript_IdAndDeletedAtIsNullOrderByChapterNumberDescSectionNumberDescCreatedAtDesc(
+                CHARACTER_ID, MANUSCRIPT_ID)).thenReturn(Optional.empty());
+        when(characterChangeLogRepository.save(any(CharacterChangeLog.class))).thenAnswer(invocation -> {
+            CharacterChangeLog log = invocation.getArgument(0);
+            log.setId(1L);
+            return log;
+        });
+
+        List<CharacterChangeLog> result = characterChangeLogService.analyzeAndPersist(MANUSCRIPT_ID, request, USER_ID);
+
+        assertEquals(1, result.size());
+        CharacterChangeLog log = result.get(0);
+        assertEquals("得知真相", log.getNewlyKnownInfo());
+        assertEquals("情绪转变", log.getCharacterChanges());
+        assertEquals("最新详情", log.getCharacterDetailsAfter());
+        assertEquals(false, log.getIsAutoCopied());
+        assertEquals(Integer.valueOf(2), log.getChapterNumber());
+        assertEquals(Integer.valueOf(5), log.getSectionNumber());
+    }
+
+    @Test
+    void analyzeAndPersist_shouldCopyPreviousDetailsWhenNoChange() {
+        AnalyzeCharacterChangesRequest request = new AnalyzeCharacterChangesRequest();
+        request.setSceneId(SCENE_ID);
+        request.setSectionContent("内容");
+        request.setCharacterIds(List.of(CHARACTER_ID));
+
+        CharacterChangeLog previous = new CharacterChangeLog();
+        previous.setCharacter(characterCard);
+        previous.setManuscript(manuscript);
+        previous.setOutline(manuscript.getOutlineCard());
+        previous.setSceneId(SCENE_ID);
+        previous.setCharacterDetailsAfter("先前详情");
+
+        when(manuscriptRepository.findById(MANUSCRIPT_ID)).thenReturn(Optional.of(manuscript));
+        doNothing().when(manuscriptService).validateManuscriptAccess(manuscript, USER_ID);
+        when(outlineSceneRepository.findById(SCENE_ID)).thenReturn(Optional.of(outlineScene));
+        when(characterCardRepository.findAllById(request.getCharacterIds())).thenReturn(List.of(characterCard));
+        when(settingsService.getDecryptedApiKeyByUserId(USER_ID)).thenReturn("api-key");
+        when(settingsService.getBaseUrlByUserId(USER_ID)).thenReturn("https://base");
+        when(settingsService.getModelNameByUserId(USER_ID)).thenReturn("gpt-test");
+        when(openAiService.generateJson(any(String.class), eq("api-key"), eq("https://base"), eq("gpt-test")))
+                .thenReturn("{" +
+                        "\"newly_known_info\":\"\"," +
+                        "\"character_changes\":\"\"," +
+                        "\"character_details_after\":\"\"," +
+                        "\"no_change\":true}" );
+        when(characterChangeLogRepository.findFirstByCharacter_IdAndManuscript_IdAndDeletedAtIsNullOrderByChapterNumberDescSectionNumberDescCreatedAtDesc(
+                CHARACTER_ID, MANUSCRIPT_ID)).thenReturn(Optional.of(previous));
+        when(characterChangeLogRepository.save(any(CharacterChangeLog.class))).thenAnswer(invocation -> {
+            CharacterChangeLog log = invocation.getArgument(0);
+            log.setId(2L);
+            return log;
+        });
+
+        List<CharacterChangeLog> result = characterChangeLogService.analyzeAndPersist(MANUSCRIPT_ID, request, USER_ID);
+
+        CharacterChangeLog log = result.get(0);
+        assertEquals("", log.getNewlyKnownInfo());
+        assertEquals("", log.getCharacterChanges());
+        assertEquals("先前详情", log.getCharacterDetailsAfter());
+        assertEquals(true, log.getIsAutoCopied());
+    }
+
+    @Test
+    void analyzeAndPersist_shouldThrowWhenAiMissingDetails() {
+        AnalyzeCharacterChangesRequest request = new AnalyzeCharacterChangesRequest();
+        request.setSceneId(SCENE_ID);
+        request.setSectionContent("内容");
+        request.setCharacterIds(List.of(CHARACTER_ID));
+
+        when(manuscriptRepository.findById(MANUSCRIPT_ID)).thenReturn(Optional.of(manuscript));
+        doNothing().when(manuscriptService).validateManuscriptAccess(manuscript, USER_ID);
+        when(outlineSceneRepository.findById(SCENE_ID)).thenReturn(Optional.of(outlineScene));
+        when(characterCardRepository.findAllById(request.getCharacterIds())).thenReturn(List.of(characterCard));
+        when(settingsService.getDecryptedApiKeyByUserId(USER_ID)).thenReturn("api-key");
+        when(settingsService.getBaseUrlByUserId(USER_ID)).thenReturn("https://base");
+        when(settingsService.getModelNameByUserId(USER_ID)).thenReturn("gpt-test");
+        when(openAiService.generateJson(any(String.class), eq("api-key"), eq("https://base"), eq("gpt-test")))
+                .thenReturn("{" +
+                        "\"newly_known_info\":\"\"," +
+                        "\"character_changes\":\"\"," +
+                        "\"no_change\":false}" );
+        when(characterChangeLogRepository.findFirstByCharacter_IdAndManuscript_IdAndDeletedAtIsNullOrderByChapterNumberDescSectionNumberDescCreatedAtDesc(
+                CHARACTER_ID, MANUSCRIPT_ID)).thenReturn(Optional.empty());
+
+        assertThrows(ResponseStatusException.class,
+                () -> characterChangeLogService.analyzeAndPersist(MANUSCRIPT_ID, request, USER_ID));
+    }
+
+    @Test
+    void analyzeAndPersist_shouldThrowWhenSceneNotInOutline() {
+        AnalyzeCharacterChangesRequest request = new AnalyzeCharacterChangesRequest();
+        request.setSceneId(SCENE_ID);
+        request.setSectionContent("内容");
+        request.setCharacterIds(List.of(CHARACTER_ID));
+
+        OutlineCard anotherOutline = new OutlineCard();
+        anotherOutline.setId(999L);
+        OutlineChapter otherChapter = new OutlineChapter();
+        otherChapter.setOutlineCard(anotherOutline);
+        OutlineScene mismatchedScene = new OutlineScene();
+        mismatchedScene.setId(SCENE_ID);
+        mismatchedScene.setOutlineChapter(otherChapter);
+        mismatchedScene.setSceneNumber(1);
+
+        when(manuscriptRepository.findById(MANUSCRIPT_ID)).thenReturn(Optional.of(manuscript));
+        doNothing().when(manuscriptService).validateManuscriptAccess(manuscript, USER_ID);
+        when(outlineSceneRepository.findById(SCENE_ID)).thenReturn(Optional.of(mismatchedScene));
+
+        assertThrows(BadRequestException.class,
+                () -> characterChangeLogService.analyzeAndPersist(MANUSCRIPT_ID, request, USER_ID));
+    }
+}
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "npx tsc -b && npx vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -22,6 +23,9 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.2",
+    "@testing-library/user-event": "^14.5.2",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.30.1",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -31,6 +35,7 @@
     "tailwindcss": "^4.1.11",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^1.6.0"
   }
 }

--- a/frontend/src/components/CharacterStatusSidebar.tsx
+++ b/frontend/src/components/CharacterStatusSidebar.tsx
@@ -1,0 +1,144 @@
+import React, { useMemo, useState } from 'react';
+import { Card, Collapse, Empty, Button, Typography, Space, Tag, Modal, List, Spin } from 'antd';
+import type { CharacterCard, CharacterChangeLog } from '../types';
+
+const { Text, Paragraph } = Typography;
+
+export interface CharacterStatusSidebarProps {
+  characterMap: Record<number, CharacterCard>;
+  logs: CharacterChangeLog[];
+  chapterNumber?: number;
+  sectionNumber?: number;
+  isAnalyzing: boolean;
+  onAnalyze?: () => void;
+}
+
+const CharacterStatusSidebar: React.FC<CharacterStatusSidebarProps> = ({
+  characterMap,
+  logs,
+  chapterNumber,
+  sectionNumber,
+  isAnalyzing,
+  onAnalyze,
+}) => {
+  const [historyVisible, setHistoryVisible] = useState(false);
+
+  const locationLabel = useMemo(() => {
+    if (chapterNumber && sectionNumber) {
+      return `第${chapterNumber}章·第${sectionNumber}节`;
+    }
+    if (chapterNumber) {
+      return `第${chapterNumber}章`;
+    }
+    return '当前场景';
+  }, [chapterNumber, sectionNumber]);
+
+  const sortedLogs = useMemo(() => {
+    return [...logs].sort((a, b) => a.characterId - b.characterId);
+  }, [logs]);
+
+  const collapseItems = useMemo(
+    () =>
+      sortedLogs.map((log) => ({
+        key: String(log.id),
+        label: (
+          <Space>
+            <span>{characterMap[log.characterId]?.name || `角色 #${log.characterId}`}</span>
+            {log.isAutoCopied && <Tag color="default">无变化</Tag>}
+          </Space>
+        ),
+        children: (
+          <Space direction="vertical" style={{ width: '100%' }}>
+            <div>
+              <Text strong>新增认知：</Text>
+              <Paragraph type={log.newlyKnownInfo ? undefined : 'secondary'}>
+                {log.newlyKnownInfo && log.newlyKnownInfo.trim() ? log.newlyKnownInfo : '无'}
+              </Paragraph>
+            </div>
+            <div>
+              <Text strong>角色变化：</Text>
+              <Paragraph type={log.characterChanges ? undefined : 'secondary'}>
+                {log.characterChanges && log.characterChanges.trim() ? log.characterChanges : '无'}
+              </Paragraph>
+            </div>
+            <div>
+              <Text strong>角色详情：</Text>
+              <Paragraph ellipsis={{ rows: 4, expandable: true, symbol: '展开' }}>
+                {log.characterDetailsAfter}
+              </Paragraph>
+            </div>
+            <Text type="secondary">更新于：{new Date(log.createdAt).toLocaleString()}</Text>
+          </Space>
+        ),
+      })),
+    [sortedLogs, characterMap]
+  );
+
+  return (
+    <Card
+      title={`角色状态追踪（${locationLabel}）`}
+      style={{ flex: 1, display: 'flex', flexDirection: 'column' }}
+      bodyStyle={{ flex: 1, overflowY: 'auto', paddingRight: 12 }}
+      extra={
+        onAnalyze ? (
+          <Button type="primary" size="small" onClick={onAnalyze} loading={isAnalyzing}>
+            重新分析
+          </Button>
+        ) : undefined
+      }
+    >
+      <Space direction="vertical" style={{ width: '100%' }} size="middle">
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <Text type="secondary">基于最新正文的角色状态总结</Text>
+          <Button type="link" size="small" onClick={() => setHistoryVisible(true)} disabled={sortedLogs.length === 0}>
+            历史记录
+          </Button>
+        </div>
+        <Spin spinning={isAnalyzing} tip="分析中...">
+          {sortedLogs.length === 0 ? (
+            <Empty description="暂无分析记录" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+          ) : (
+            <Collapse bordered={false} items={collapseItems} size="small" />
+          )}
+        </Spin>
+      </Space>
+      <Modal
+        title="角色状态历史"
+        open={historyVisible}
+        onCancel={() => setHistoryVisible(false)}
+        footer={null}
+        width={560}
+      >
+        {sortedLogs.length === 0 ? (
+          <Empty description="暂无记录" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+        ) : (
+          <List
+            dataSource={sortedLogs}
+            renderItem={(log) => (
+              <List.Item key={log.id} style={{ alignItems: 'flex-start' }}>
+                <List.Item.Meta
+                  title={`${characterMap[log.characterId]?.name || `角色 #${log.characterId}`} · ${new Date(log.createdAt).toLocaleString()}`}
+                  description={
+                    <Space direction="vertical" style={{ width: '100%' }} size={4}>
+                      <div>
+                        <Text strong>角色变化：</Text>
+                        <Text>{log.characterChanges && log.characterChanges.trim() ? log.characterChanges : '无'}</Text>
+                      </div>
+                      <div>
+                        <Text strong>角色详情：</Text>
+                        <Paragraph>{log.characterDetailsAfter}</Paragraph>
+                      </div>
+                    </Space>
+                  }
+                />
+              </List.Item>
+            )}
+          />
+        )}
+      </Modal>
+    </Card>
+  );
+};
+
+export default CharacterStatusSidebar;
+

--- a/frontend/src/components/__tests__/CharacterStatusSidebar.test.tsx
+++ b/frontend/src/components/__tests__/CharacterStatusSidebar.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CharacterStatusSidebar from '../CharacterStatusSidebar';
+import type { CharacterChangeLog, CharacterCard } from '../../types';
+
+const characterMap: Record<number, CharacterCard> = {
+  1: { id: 1, name: '林渊', synopsis: '', details: '', relationships: '' },
+};
+
+const logs: CharacterChangeLog[] = [
+  {
+    id: 10,
+    characterId: 1,
+    chapterNumber: 1,
+    sectionNumber: 2,
+    newlyKnownInfo: '得知真相',
+    characterChanges: '情绪变化',
+    characterDetailsAfter: '新的角色画像',
+    isAutoCopied: false,
+    createdAt: new Date(2024, 4, 1, 10, 30).toISOString(),
+  },
+];
+
+describe('CharacterStatusSidebar', () => {
+  it('renders character logs and opens history modal', () => {
+    render(
+      <CharacterStatusSidebar
+        characterMap={characterMap}
+        logs={logs}
+        chapterNumber={2}
+        sectionNumber={3}
+        isAnalyzing={false}
+      />
+    );
+
+    expect(screen.getByText('角色状态追踪（第2章·第3节）')).toBeInTheDocument();
+    expect(screen.getByText('林渊')).toBeInTheDocument();
+    expect(screen.getByText('得知真相')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '历史记录' }));
+
+    expect(screen.getByText(/角色变化：/)).toBeInTheDocument();
+    expect(screen.getByText('新的角色画像')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no logs', () => {
+    render(
+      <CharacterStatusSidebar
+        characterMap={{}}
+        logs={[]}
+        isAnalyzing={false}
+      />
+    );
+
+    expect(screen.getByText('暂无分析记录')).toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/components/__tests__/ManuscriptWriter.test.tsx
+++ b/frontend/src/components/__tests__/ManuscriptWriter.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ManuscriptWriter from '../ManuscriptWriter';
+
+const analyzeCharacterChangesMock = vi.fn();
+const fetchCharacterChangeLogsMock = vi.fn();
+
+vi.mock('../../services/api', () => ({
+  fetchStories: vi.fn().mockResolvedValue([{ id: 1, title: '故事一', synopsis: '', storyArc: '', genre: '', tone: '' }]),
+  fetchStoryDetails: vi.fn().mockResolvedValue({
+    storyCard: { id: 1, title: '故事一', synopsis: '', storyArc: '', genre: '', tone: '' },
+    characterCards: [
+      { id: 1001, name: '林渊', synopsis: '', details: '', relationships: '' },
+    ],
+  }),
+  fetchManuscriptsForOutline: vi.fn().mockResolvedValue([
+    { id: 200, title: '手稿A', outlineId: 1, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+  ]),
+  fetchManuscriptWithSections: vi.fn().mockResolvedValue({
+    manuscript: { id: 200, title: '手稿A', outlineId: 1, createdAt: '', updatedAt: '' },
+    sections: {
+      101: { id: 300, content: '原始正文', version: 1, sceneId: 101 },
+    },
+  }),
+  createManuscript: vi.fn(),
+  deleteManuscript: vi.fn(),
+  analyzeCharacterChanges: analyzeCharacterChangesMock,
+  fetchCharacterChangeLogs: fetchCharacterChangeLogsMock,
+}));
+
+const outlineDetail = {
+  id: 1,
+  title: '大纲一',
+  pointOfView: '',
+  chapters: [
+    {
+      id: 10,
+      chapterNumber: 2,
+      title: '第二章',
+      synopsis: '',
+      scenes: [
+        {
+          id: 101,
+          sceneNumber: 4,
+          synopsis: '场景概要',
+          expectedWords: 800,
+          presentCharacterIds: [1001],
+          presentCharacters: '',
+          characterStates: '',
+          temporaryCharacters: [],
+        },
+      ],
+    },
+  ],
+};
+
+vi.mock('../../hooks/useOutlineData', () => ({
+  useOutlineData: () => ({
+    outlines: [{ id: 1, title: '大纲一', pointOfView: '', chapters: [] }],
+    selectedOutline: { id: 1, title: '大纲一', pointOfView: '', chapters: [] },
+    selectOutline: vi.fn(),
+    getOutlineForWriting: vi.fn().mockResolvedValue(outlineDetail),
+    loadOutlines: vi.fn(),
+  }),
+}));
+
+describe('ManuscriptWriter runCharacterAnalysis', () => {
+  beforeEach(() => {
+    analyzeCharacterChangesMock.mockClear();
+    fetchCharacterChangeLogsMock.mockClear();
+    analyzeCharacterChangesMock.mockResolvedValue([
+      {
+        id: 900,
+        characterId: 1001,
+        chapterNumber: 2,
+        sectionNumber: 4,
+        newlyKnownInfo: '新信息',
+        characterChanges: '状态改变',
+        characterDetailsAfter: '更新后的详情',
+        isAutoCopied: false,
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+    fetchCharacterChangeLogsMock.mockResolvedValue([]);
+  });
+
+  it('triggers character analysis and renders results', async () => {
+    render(<ManuscriptWriter storyId="1" selectedSceneId={101} onSelectScene={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('手稿A')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('手稿A'));
+
+    await waitFor(() => expect(screen.getByText('原始正文')).toBeInTheDocument());
+
+    const analyzeButton = await screen.findByRole('button', { name: '分析角色变化' });
+    fireEvent.click(analyzeButton);
+
+    await waitFor(() => expect(analyzeCharacterChangesMock).toHaveBeenCalled());
+
+    expect(analyzeCharacterChangesMock).toHaveBeenCalledWith(200, expect.objectContaining({
+      sceneId: 101,
+      characterIds: [1001],
+      sectionContent: '原始正文',
+    }));
+
+    await waitFor(() => expect(screen.getByText('状态改变')).toBeInTheDocument());
+  });
+});
+

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,14 @@
-import type { StoryCard, CharacterCard, Outline, ConceptionFormValues, Chapter, Manuscript, ManuscriptSection } from '../types';
+import type {
+    StoryCard,
+    CharacterCard,
+    Outline,
+    ConceptionFormValues,
+    Chapter,
+    Manuscript,
+    ManuscriptSection,
+    CharacterChangeLog,
+    AnalyzeCharacterChangesPayload,
+} from '../types';
 
 /**
  * Creates authorization headers for API requests.
@@ -313,4 +323,24 @@ export const deleteManuscript = (manuscriptId: number): Promise<void> => {
         method: 'DELETE',
         headers: getAuthHeaders(),
     }).then(res => handleResponse<void>(res));
+};
+
+export const analyzeCharacterChanges = (
+    manuscriptId: number,
+    payload: AnalyzeCharacterChangesPayload
+): Promise<CharacterChangeLog[]> => {
+    return fetch(`/api/v1/manuscripts/${manuscriptId}/sections/analyze-character-changes`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(payload),
+    }).then(res => handleResponse<CharacterChangeLog[]>(res));
+};
+
+export const fetchCharacterChangeLogs = (
+    manuscriptId: number,
+    sceneId: number
+): Promise<CharacterChangeLog[]> => {
+    return fetch(`/api/v1/manuscripts/${manuscriptId}/sections/${sceneId}/character-change-logs`, {
+        headers: getAuthHeaders(),
+    }).then(res => handleResponse<CharacterChangeLog[]>(res));
 };

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom';
+

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -73,6 +73,27 @@ export interface CharacterCard {
     relationships: string;
 }
 
+export interface CharacterChangeLog {
+    id: number;
+    characterId: number;
+    chapterNumber: number;
+    sectionNumber: number;
+    newlyKnownInfo?: string;
+    characterChanges?: string;
+    characterDetailsAfter: string;
+    isAutoCopied: boolean;
+    createdAt: string;
+}
+
+export interface AnalyzeCharacterChangesPayload {
+    sceneId: number;
+    chapterNumber?: number;
+    sectionNumber?: number;
+    sectionContent: string;
+    characterIds: number[];
+    outlineId?: number;
+}
+
 export interface ManuscriptSection {
     id: number;
     content: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,4 +23,9 @@ export default defineConfig({
     emptyOutDir: true,
     minify: false,
   },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+    globals: true,
+  },
 })


### PR DESCRIPTION
## Summary
- add the character_change_logs schema, JPA entity, repository, and service logic to call the AI analyzer and persist structured results
- expose REST endpoints for analyzing sections and loading logs plus extend ManuscriptService to delegate to the new workflow
- introduce a character status sidebar on the manuscript writer, wire up API helpers, and cover the flow with unit tests on both backend and frontend

## Testing
- mvn test *(fails: parent POM cannot be downloaded because the Maven Central repository is unreachable in this environment)*
- npm test -- --runTestsByPath src/components/__tests__/CharacterStatusSidebar.test.tsx *(fails: vitest is not available because frontend test dependencies are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cabdfcd2888330a07987ee6b31d140