### PR TITLE
Integrate prompt template infrastructure and refactor manuscript generation

### DIFF
--- a/backend/src/main/java/com/example/ainovel/controller/PromptTemplateController.java
+++ b/backend/src/main/java/com/example/ainovel/controller/PromptTemplateController.java
@@ -1,0 +1,52 @@
+package com.example.ainovel.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.ainovel.dto.prompt.PromptTemplateMetadataResponse;
+import com.example.ainovel.dto.prompt.PromptTemplatesResetRequest;
+import com.example.ainovel.dto.prompt.PromptTemplatesResponse;
+import com.example.ainovel.dto.prompt.PromptTemplatesUpdateRequest;
+import com.example.ainovel.model.User;
+import com.example.ainovel.prompt.PromptTemplateService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/prompt-templates")
+@RequiredArgsConstructor
+public class PromptTemplateController {
+
+    private final PromptTemplateService promptTemplateService;
+
+    @GetMapping
+    public PromptTemplatesResponse getTemplates(@AuthenticationPrincipal User user) {
+        Long userId = user != null ? user.getId() : null;
+        return promptTemplateService.getEffectiveTemplates(userId);
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> saveTemplates(@AuthenticationPrincipal User user,
+                                              @RequestBody PromptTemplatesUpdateRequest request) {
+        promptTemplateService.saveTemplates(user.getId(), request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/reset")
+    public ResponseEntity<Void> resetTemplates(@AuthenticationPrincipal User user,
+                                               @RequestBody PromptTemplatesResetRequest request) {
+        promptTemplateService.resetTemplates(user.getId(), request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/metadata")
+    public PromptTemplateMetadataResponse getMetadata() {
+        return promptTemplateService.getMetadata();
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/prompt/PromptFunctionMetadataDto.java
+++ b/backend/src/main/java/com/example/ainovel/dto/prompt/PromptFunctionMetadataDto.java
@@ -1,0 +1,44 @@
+package com.example.ainovel.dto.prompt;
+
+public class PromptFunctionMetadataDto {
+
+    private String name;
+    private String description;
+    private String usage;
+
+    public PromptFunctionMetadataDto() {
+    }
+
+    public PromptFunctionMetadataDto(String name, String description, String usage) {
+        this.name = name;
+        this.description = description;
+        this.usage = usage;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public PromptFunctionMetadataDto setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public PromptFunctionMetadataDto setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public String getUsage() {
+        return usage;
+    }
+
+    public PromptFunctionMetadataDto setUsage(String usage) {
+        this.usage = usage;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/prompt/PromptTemplateItemDto.java
+++ b/backend/src/main/java/com/example/ainovel/dto/prompt/PromptTemplateItemDto.java
@@ -1,0 +1,33 @@
+package com.example.ainovel.dto.prompt;
+
+public class PromptTemplateItemDto {
+
+    private String content;
+    private boolean isDefault;
+
+    public PromptTemplateItemDto() {
+    }
+
+    public PromptTemplateItemDto(String content, boolean isDefault) {
+        this.content = content;
+        this.isDefault = isDefault;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public PromptTemplateItemDto setContent(String content) {
+        this.content = content;
+        return this;
+    }
+
+    public boolean isDefault() {
+        return isDefault;
+    }
+
+    public PromptTemplateItemDto setDefault(boolean aDefault) {
+        isDefault = aDefault;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/prompt/PromptTemplateMetadataResponse.java
+++ b/backend/src/main/java/com/example/ainovel/dto/prompt/PromptTemplateMetadataResponse.java
@@ -1,0 +1,47 @@
+package com.example.ainovel.dto.prompt;
+
+import java.util.List;
+
+public class PromptTemplateMetadataResponse {
+
+    private List<PromptTypeMetadataDto> templates;
+    private List<PromptFunctionMetadataDto> functions;
+    private List<String> syntaxTips;
+    private List<String> examples;
+
+    public List<PromptTypeMetadataDto> getTemplates() {
+        return templates;
+    }
+
+    public PromptTemplateMetadataResponse setTemplates(List<PromptTypeMetadataDto> templates) {
+        this.templates = templates;
+        return this;
+    }
+
+    public List<PromptFunctionMetadataDto> getFunctions() {
+        return functions;
+    }
+
+    public PromptTemplateMetadataResponse setFunctions(List<PromptFunctionMetadataDto> functions) {
+        this.functions = functions;
+        return this;
+    }
+
+    public List<String> getSyntaxTips() {
+        return syntaxTips;
+    }
+
+    public PromptTemplateMetadataResponse setSyntaxTips(List<String> syntaxTips) {
+        this.syntaxTips = syntaxTips;
+        return this;
+    }
+
+    public List<String> getExamples() {
+        return examples;
+    }
+
+    public PromptTemplateMetadataResponse setExamples(List<String> examples) {
+        this.examples = examples;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/prompt/PromptTemplatesResetRequest.java
+++ b/backend/src/main/java/com/example/ainovel/dto/prompt/PromptTemplatesResetRequest.java
@@ -1,0 +1,17 @@
+package com.example.ainovel.dto.prompt;
+
+import java.util.List;
+
+public class PromptTemplatesResetRequest {
+
+    private List<String> keys;
+
+    public List<String> getKeys() {
+        return keys;
+    }
+
+    public PromptTemplatesResetRequest setKeys(List<String> keys) {
+        this.keys = keys;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/prompt/PromptTemplatesResponse.java
+++ b/backend/src/main/java/com/example/ainovel/dto/prompt/PromptTemplatesResponse.java
@@ -1,0 +1,45 @@
+package com.example.ainovel.dto.prompt;
+
+public class PromptTemplatesResponse {
+
+    private PromptTemplateItemDto storyCreation;
+    private PromptTemplateItemDto outlineChapter;
+    private PromptTemplateItemDto manuscriptSection;
+    private RefinePromptTemplateDto refine;
+
+    public PromptTemplateItemDto getStoryCreation() {
+        return storyCreation;
+    }
+
+    public PromptTemplatesResponse setStoryCreation(PromptTemplateItemDto storyCreation) {
+        this.storyCreation = storyCreation;
+        return this;
+    }
+
+    public PromptTemplateItemDto getOutlineChapter() {
+        return outlineChapter;
+    }
+
+    public PromptTemplatesResponse setOutlineChapter(PromptTemplateItemDto outlineChapter) {
+        this.outlineChapter = outlineChapter;
+        return this;
+    }
+
+    public PromptTemplateItemDto getManuscriptSection() {
+        return manuscriptSection;
+    }
+
+    public PromptTemplatesResponse setManuscriptSection(PromptTemplateItemDto manuscriptSection) {
+        this.manuscriptSection = manuscriptSection;
+        return this;
+    }
+
+    public RefinePromptTemplateDto getRefine() {
+        return refine;
+    }
+
+    public PromptTemplatesResponse setRefine(RefinePromptTemplateDto refine) {
+        this.refine = refine;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/prompt/PromptTemplatesUpdateRequest.java
+++ b/backend/src/main/java/com/example/ainovel/dto/prompt/PromptTemplatesUpdateRequest.java
@@ -1,0 +1,45 @@
+package com.example.ainovel.dto.prompt;
+
+public class PromptTemplatesUpdateRequest {
+
+    private String storyCreation;
+    private String outlineChapter;
+    private String manuscriptSection;
+    private RefinePromptTemplatesUpdateRequest refine;
+
+    public String getStoryCreation() {
+        return storyCreation;
+    }
+
+    public PromptTemplatesUpdateRequest setStoryCreation(String storyCreation) {
+        this.storyCreation = storyCreation;
+        return this;
+    }
+
+    public String getOutlineChapter() {
+        return outlineChapter;
+    }
+
+    public PromptTemplatesUpdateRequest setOutlineChapter(String outlineChapter) {
+        this.outlineChapter = outlineChapter;
+        return this;
+    }
+
+    public String getManuscriptSection() {
+        return manuscriptSection;
+    }
+
+    public PromptTemplatesUpdateRequest setManuscriptSection(String manuscriptSection) {
+        this.manuscriptSection = manuscriptSection;
+        return this;
+    }
+
+    public RefinePromptTemplatesUpdateRequest getRefine() {
+        return refine;
+    }
+
+    public PromptTemplatesUpdateRequest setRefine(RefinePromptTemplatesUpdateRequest refine) {
+        this.refine = refine;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/prompt/PromptTypeMetadataDto.java
+++ b/backend/src/main/java/com/example/ainovel/dto/prompt/PromptTypeMetadataDto.java
@@ -1,0 +1,46 @@
+package com.example.ainovel.dto.prompt;
+
+import java.util.List;
+
+public class PromptTypeMetadataDto {
+
+    private String type;
+    private String label;
+    private List<PromptVariableMetadataDto> variables;
+
+    public PromptTypeMetadataDto() {
+    }
+
+    public PromptTypeMetadataDto(String type, String label, List<PromptVariableMetadataDto> variables) {
+        this.type = type;
+        this.label = label;
+        this.variables = variables;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public PromptTypeMetadataDto setType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public PromptTypeMetadataDto setLabel(String label) {
+        this.label = label;
+        return this;
+    }
+
+    public List<PromptVariableMetadataDto> getVariables() {
+        return variables;
+    }
+
+    public PromptTypeMetadataDto setVariables(List<PromptVariableMetadataDto> variables) {
+        this.variables = variables;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/prompt/PromptVariableMetadataDto.java
+++ b/backend/src/main/java/com/example/ainovel/dto/prompt/PromptVariableMetadataDto.java
@@ -1,0 +1,44 @@
+package com.example.ainovel.dto.prompt;
+
+public class PromptVariableMetadataDto {
+
+    private String name;
+    private String valueType;
+    private String description;
+
+    public PromptVariableMetadataDto() {
+    }
+
+    public PromptVariableMetadataDto(String name, String valueType, String description) {
+        this.name = name;
+        this.valueType = valueType;
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public PromptVariableMetadataDto setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getValueType() {
+        return valueType;
+    }
+
+    public PromptVariableMetadataDto setValueType(String valueType) {
+        this.valueType = valueType;
+        return this;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public PromptVariableMetadataDto setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/prompt/RefinePromptTemplateDto.java
+++ b/backend/src/main/java/com/example/ainovel/dto/prompt/RefinePromptTemplateDto.java
@@ -1,0 +1,25 @@
+package com.example.ainovel.dto.prompt;
+
+public class RefinePromptTemplateDto {
+
+    private PromptTemplateItemDto withInstruction;
+    private PromptTemplateItemDto withoutInstruction;
+
+    public PromptTemplateItemDto getWithInstruction() {
+        return withInstruction;
+    }
+
+    public RefinePromptTemplateDto setWithInstruction(PromptTemplateItemDto withInstruction) {
+        this.withInstruction = withInstruction;
+        return this;
+    }
+
+    public PromptTemplateItemDto getWithoutInstruction() {
+        return withoutInstruction;
+    }
+
+    public RefinePromptTemplateDto setWithoutInstruction(PromptTemplateItemDto withoutInstruction) {
+        this.withoutInstruction = withoutInstruction;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/prompt/RefinePromptTemplatesUpdateRequest.java
+++ b/backend/src/main/java/com/example/ainovel/dto/prompt/RefinePromptTemplatesUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.example.ainovel.dto.prompt;
+
+public class RefinePromptTemplatesUpdateRequest {
+
+    private String withInstruction;
+    private String withoutInstruction;
+
+    public String getWithInstruction() {
+        return withInstruction;
+    }
+
+    public RefinePromptTemplatesUpdateRequest setWithInstruction(String withInstruction) {
+        this.withInstruction = withInstruction;
+        return this;
+    }
+
+    public String getWithoutInstruction() {
+        return withoutInstruction;
+    }
+
+    public RefinePromptTemplatesUpdateRequest setWithoutInstruction(String withoutInstruction) {
+        this.withoutInstruction = withoutInstruction;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/model/UserSetting.java
+++ b/backend/src/main/java/com/example/ainovel/model/UserSetting.java
@@ -1,5 +1,8 @@
 package com.example.ainovel.model;
 
+import com.example.ainovel.model.prompt.PromptSettings;
+import com.example.ainovel.model.prompt.PromptSettingsAttributeConverter;
+
 import jakarta.persistence.*;
 
 @Entity
@@ -25,6 +28,10 @@ public class UserSetting {
 
     @Column(columnDefinition = "TEXT")
     private String customPrompt;
+
+    @Column(name = "prompt_settings", columnDefinition = "LONGTEXT")
+    @Convert(converter = PromptSettingsAttributeConverter.class)
+    private PromptSettings promptSettings;
 
     // Getters and Setters
 
@@ -74,5 +81,13 @@ public class UserSetting {
 
     public void setCustomPrompt(String customPrompt) {
         this.customPrompt = customPrompt;
+    }
+
+    public PromptSettings getPromptSettings() {
+        return promptSettings;
+    }
+
+    public void setPromptSettings(PromptSettings promptSettings) {
+        this.promptSettings = promptSettings;
     }
 }

--- a/backend/src/main/java/com/example/ainovel/model/prompt/PromptSettings.java
+++ b/backend/src/main/java/com/example/ainovel/model/prompt/PromptSettings.java
@@ -1,0 +1,52 @@
+package com.example.ainovel.model.prompt;
+
+public class PromptSettings {
+
+    private String storyCreation;
+    private String outlineChapter;
+    private String manuscriptSection;
+    private RefinePromptSettings refine;
+
+    public String getStoryCreation() {
+        return storyCreation;
+    }
+
+    public PromptSettings setStoryCreation(String storyCreation) {
+        this.storyCreation = storyCreation;
+        return this;
+    }
+
+    public String getOutlineChapter() {
+        return outlineChapter;
+    }
+
+    public PromptSettings setOutlineChapter(String outlineChapter) {
+        this.outlineChapter = outlineChapter;
+        return this;
+    }
+
+    public String getManuscriptSection() {
+        return manuscriptSection;
+    }
+
+    public PromptSettings setManuscriptSection(String manuscriptSection) {
+        this.manuscriptSection = manuscriptSection;
+        return this;
+    }
+
+    public RefinePromptSettings getRefine() {
+        return refine;
+    }
+
+    public PromptSettings setRefine(RefinePromptSettings refine) {
+        this.refine = refine;
+        return this;
+    }
+
+    public RefinePromptSettings ensureRefine() {
+        if (this.refine == null) {
+            this.refine = new RefinePromptSettings();
+        }
+        return this.refine;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/model/prompt/PromptSettingsAttributeConverter.java
+++ b/backend/src/main/java/com/example/ainovel/model/prompt/PromptSettingsAttributeConverter.java
@@ -1,0 +1,41 @@
+package com.example.ainovel.model.prompt;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class PromptSettingsAttributeConverter implements AttributeConverter<PromptSettings, String> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    static {
+        OBJECT_MAPPER.findAndRegisterModules();
+    }
+
+    @Override
+    public String convertToDatabaseColumn(PromptSettings attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize prompt settings", e);
+        }
+    }
+
+    @Override
+    public PromptSettings convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.readValue(dbData, PromptSettings.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize prompt settings", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/model/prompt/RefinePromptSettings.java
+++ b/backend/src/main/java/com/example/ainovel/model/prompt/RefinePromptSettings.java
@@ -1,0 +1,25 @@
+package com.example.ainovel.model.prompt;
+
+public class RefinePromptSettings {
+
+    private String withInstruction;
+    private String withoutInstruction;
+
+    public String getWithInstruction() {
+        return withInstruction;
+    }
+
+    public RefinePromptSettings setWithInstruction(String withInstruction) {
+        this.withInstruction = withInstruction;
+        return this;
+    }
+
+    public String getWithoutInstruction() {
+        return withoutInstruction;
+    }
+
+    public RefinePromptSettings setWithoutInstruction(String withoutInstruction) {
+        this.withoutInstruction = withoutInstruction;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/PromptConfiguration.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/PromptConfiguration.java
@@ -1,0 +1,29 @@
+package com.example.ainovel.prompt;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+@Configuration
+public class PromptConfiguration {
+
+    @Bean
+    public PromptDefaults promptDefaults() {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.findAndRegisterModules();
+        ClassPathResource resource = new ClassPathResource("prompts/default-prompts.yaml");
+        try (InputStream inputStream = resource.getInputStream()) {
+            PromptDefaults defaults = mapper.readValue(inputStream, PromptDefaults.class);
+            defaults.validate();
+            return defaults;
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load default prompt templates", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/PromptDefaults.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/PromptDefaults.java
@@ -1,0 +1,60 @@
+package com.example.ainovel.prompt;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PromptDefaults {
+
+    private String storyCreation;
+    private String outlineChapter;
+    private String manuscriptSection;
+    private RefinePromptDefaults refine;
+
+    public String getStoryCreation() {
+        return storyCreation;
+    }
+
+    public void setStoryCreation(String storyCreation) {
+        this.storyCreation = storyCreation;
+    }
+
+    public String getOutlineChapter() {
+        return outlineChapter;
+    }
+
+    public void setOutlineChapter(String outlineChapter) {
+        this.outlineChapter = outlineChapter;
+    }
+
+    public String getManuscriptSection() {
+        return manuscriptSection;
+    }
+
+    public void setManuscriptSection(String manuscriptSection) {
+        this.manuscriptSection = manuscriptSection;
+    }
+
+    public RefinePromptDefaults getRefine() {
+        return refine;
+    }
+
+    public void setRefine(RefinePromptDefaults refine) {
+        this.refine = refine;
+    }
+
+    public void validate() {
+        if (storyCreation == null || storyCreation.isBlank()) {
+            throw new IllegalStateException("Default story creation prompt must not be empty");
+        }
+        if (outlineChapter == null || outlineChapter.isBlank()) {
+            throw new IllegalStateException("Default outline chapter prompt must not be empty");
+        }
+        if (manuscriptSection == null || manuscriptSection.isBlank()) {
+            throw new IllegalStateException("Default manuscript section prompt must not be empty");
+        }
+        if (refine == null) {
+            throw new IllegalStateException("Default refine prompts must be provided");
+        }
+        refine.validate();
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/PromptTemplateException.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/PromptTemplateException.java
@@ -1,0 +1,12 @@
+package com.example.ainovel.prompt;
+
+public class PromptTemplateException extends RuntimeException {
+
+    public PromptTemplateException(String message) {
+        super(message);
+    }
+
+    public PromptTemplateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/PromptTemplateMetadataProvider.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/PromptTemplateMetadataProvider.java
@@ -1,0 +1,120 @@
+package com.example.ainovel.prompt;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.example.ainovel.dto.prompt.PromptFunctionMetadataDto;
+import com.example.ainovel.dto.prompt.PromptTemplateMetadataResponse;
+import com.example.ainovel.dto.prompt.PromptTypeMetadataDto;
+import com.example.ainovel.dto.prompt.PromptVariableMetadataDto;
+
+@Component
+public class PromptTemplateMetadataProvider {
+
+    public PromptTemplateMetadataResponse getMetadata() {
+        return new PromptTemplateMetadataResponse()
+                .setTemplates(List.of(
+                        new PromptTypeMetadataDto(
+                                "storyCreation",
+                                "故事构思",
+                                List.of(
+                                        new PromptVariableMetadataDto("idea", "string", "用户填写的核心想法。"),
+                                        new PromptVariableMetadataDto("type", "string", "`genre` 的别名，便于在模板中书写。"),
+                                        new PromptVariableMetadataDto("genre", "string", "故事类型。"),
+                                        new PromptVariableMetadataDto("tone", "string", "故事基调。"),
+                                        new PromptVariableMetadataDto("tags", "string[]", "标签数组，可搭配 `[index]` 或 `[*]` 使用。"),
+                                        new PromptVariableMetadataDto("tag", "string[]", "`tags` 的别名，作用相同。"),
+                                        new PromptVariableMetadataDto("context.summary", "string", "自动汇总的上下文块，包含想法、类型、基调与标签。"),
+                                        new PromptVariableMetadataDto("context.lines.idea", "string", "当提供想法时为 `核心想法：...\\n`，否则为空。"),
+                                        new PromptVariableMetadataDto("context.lines.genre", "string", "类型对应的单行提示文本。"),
+                                        new PromptVariableMetadataDto("context.lines.tone", "string", "基调对应的单行提示文本。"),
+                                        new PromptVariableMetadataDto("context.lines.tags", "string", "标签对应的单行提示文本。"),
+                                        new PromptVariableMetadataDto("request.raw", "object", "原始的 `ConceptionRequest` 对象。")
+                                )
+                        ),
+                        new PromptTypeMetadataDto(
+                                "outlineChapter",
+                                "大纲章节",
+                                List.of(
+                                        new PromptVariableMetadataDto("story.title", "string", "故事标题。"),
+                                        new PromptVariableMetadataDto("story.synopsis", "string", "故事简介。"),
+                                        new PromptVariableMetadataDto("story.genre", "string", "故事类型。"),
+                                        new PromptVariableMetadataDto("story.tone", "string", "故事基调。"),
+                                        new PromptVariableMetadataDto("story.storyArc", "string", "长线剧情走向。"),
+                                        new PromptVariableMetadataDto("outline.title", "string", "大纲名称。"),
+                                        new PromptVariableMetadataDto("outline.pointOfView", "string", "叙事视角，可为空。"),
+                                        new PromptVariableMetadataDto("chapter.number", "number", "当前章节编号。"),
+                                        new PromptVariableMetadataDto("chapter.sectionsPerChapter", "number", "预设节数。"),
+                                        new PromptVariableMetadataDto("chapter.wordsPerSection", "number", "预估每节字数。"),
+                                        new PromptVariableMetadataDto("chapter.previousSynopsis", "string", "上一章梗概，首章为“无，这是第一章。”"),
+                                        new PromptVariableMetadataDto("characters.list", "object[]", "故事主要角色列表（含简介/详情/关系）。"),
+                                        new PromptVariableMetadataDto("characters.summary", "string", "预格式化的角色条目文本。"),
+                                        new PromptVariableMetadataDto("characters.names", "string[]", "角色姓名数组。"),
+                                        new PromptVariableMetadataDto("request.raw", "object", "原始的 `GenerateChapterRequest` 对象。")
+                                )
+                        ),
+                        new PromptTypeMetadataDto(
+                                "manuscriptSection",
+                                "正文创作",
+                                List.of(
+                                        new PromptVariableMetadataDto("story.title", "string", "故事标题。"),
+                                        new PromptVariableMetadataDto("story.genre", "string", "故事类型。"),
+                                        new PromptVariableMetadataDto("story.tone", "string", "故事基调。"),
+                                        new PromptVariableMetadataDto("story.synopsis", "string", "故事简介。"),
+                                        new PromptVariableMetadataDto("outline.pointOfView", "string", "叙事视角，默认为第三人称有限视角。"),
+                                        new PromptVariableMetadataDto("characters.all", "object[]", "全部角色档案。"),
+                                        new PromptVariableMetadataDto("characters.allSummary", "string", "预格式化的角色档案文本。"),
+                                        new PromptVariableMetadataDto("characters.present", "string[]", "当前场景出场人物姓名数组。"),
+                                        new PromptVariableMetadataDto("scene.number", "number", "当前小节编号。"),
+                                        new PromptVariableMetadataDto("scene.totalInChapter", "number", "本章总小节数。"),
+                                        new PromptVariableMetadataDto("scene.synopsis", "string", "本节梗概。"),
+                                        new PromptVariableMetadataDto("scene.expectedWords", "number", "期望字数。"),
+                                        new PromptVariableMetadataDto("scene.coreCharacters", "object[]", "核心人物状态卡数据。"),
+                                        new PromptVariableMetadataDto("scene.coreCharacterSummary", "string", "核心人物状态卡文本。"),
+                                        new PromptVariableMetadataDto("scene.temporaryCharacters", "object[]", "临时人物数组。"),
+                                        new PromptVariableMetadataDto("scene.temporaryCharacterSummary", "string", "临时人物文本。"),
+                                        new PromptVariableMetadataDto("scene.presentCharacters", "string", "本节出场人物名称字符串。"),
+                                        new PromptVariableMetadataDto("previousSection.content", "string", "上一节正文原文。"),
+                                        new PromptVariableMetadataDto("previousChapter.scenes", "object[]", "上一章全部场景大纲。"),
+                                        new PromptVariableMetadataDto("previousChapter.summary", "string", "上一章大纲摘要。"),
+                                        new PromptVariableMetadataDto("currentChapter.scenes", "object[]", "本章全部场景大纲。"),
+                                        new PromptVariableMetadataDto("currentChapter.summary", "string", "本章大纲摘要。"),
+                                        new PromptVariableMetadataDto("chapter.number", "number", "当前章号。"),
+                                        new PromptVariableMetadataDto("chapter.total", "number", "总章节数。"),
+                                        new PromptVariableMetadataDto("chapter.title", "string", "当前章标题。"),
+                                        new PromptVariableMetadataDto("log.latestByCharacter", "map", "角色 -> 最近成长日志摘要。")
+                                )
+                        ),
+                        new PromptTypeMetadataDto(
+                                "refine",
+                                "文本润色",
+                                List.of(
+                                        new PromptVariableMetadataDto("text", "string", "原始文本。"),
+                                        new PromptVariableMetadataDto("instruction", "string", "优化指令（仅在带指令模板中使用）。"),
+                                        new PromptVariableMetadataDto("contextType", "string", "文本类型描述，例如“角色介绍”。"),
+                                        new PromptVariableMetadataDto("context.note", "string", "基于 `contextType` 生成的提示语。"),
+                                        new PromptVariableMetadataDto("request.raw", "object", "原始的 `RefineRequest` 对象。")
+                                )
+                        )
+                ))
+                .setFunctions(List.of(
+                        new PromptFunctionMetadataDto("default(value)", "当前值为空字符串时返回备用值。", "${genre|default(\"未指定类型\")}"),
+                        new PromptFunctionMetadataDto("join(separator)", "将数组或列表按分隔符拼接。", "${tags[*]|join(\"，\")}"),
+                        new PromptFunctionMetadataDto("upper()", "将字符串转为大写。", "${tone|upper()}"),
+                        new PromptFunctionMetadataDto("lower()", "将字符串转为小写。", "${contextType|lower()}"),
+                        new PromptFunctionMetadataDto("trim()", "去除首尾空白。", "${idea|trim()}"),
+                        new PromptFunctionMetadataDto("json()", "序列化为 JSON 字符串，便于调试或日志记录。", "${scene.coreCharacters|json()}")
+                ))
+                .setSyntaxTips(List.of(
+                        "使用 `${变量}` 插入上下文，支持嵌套访问，例如 `${story.title}`。",
+                        "列表支持 `[索引]` 与 `[*]` 语法；`[*]` 默认使用顿号连接，可配合 `|join()` 自定义分隔符。",
+                        "可以链式调用函数，如 `${tags[*]|join(\"，\")|upper()}`。"
+                ))
+                .setExamples(List.of(
+                        "${context.lines.tags|default(\"标签：暂无\")}",
+                        "${characters.present[*]|join(\"、\")}",
+                        "${previousSection.content|trim()}"
+                ));
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/PromptTemplateRepository.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/PromptTemplateRepository.java
@@ -1,0 +1,55 @@
+package com.example.ainovel.prompt;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.example.ainovel.model.User;
+import com.example.ainovel.model.UserSetting;
+import com.example.ainovel.model.prompt.PromptSettings;
+import com.example.ainovel.repository.UserRepository;
+import com.example.ainovel.repository.UserSettingRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PromptTemplateRepository {
+
+    private final UserSettingRepository userSettingRepository;
+    private final UserRepository userRepository;
+
+    public Optional<PromptSettings> findByUserId(Long userId) {
+        return userSettingRepository.findByUserId(userId)
+                .map(UserSetting::getPromptSettings)
+                .filter(settings -> settings != null);
+    }
+
+    public PromptSettings save(Long userId, PromptSettings promptSettings) {
+        UserSetting setting = userSettingRepository.findByUserId(userId)
+                .orElseGet(() -> createSettingForUser(userId));
+        setting.setPromptSettings(promptSettings);
+        userSettingRepository.save(setting);
+        return promptSettings;
+    }
+
+    public void clearTemplate(Long userId, java.util.function.Consumer<PromptSettings> clearer) {
+        UserSetting setting = userSettingRepository.findByUserId(userId)
+                .orElseGet(() -> createSettingForUser(userId));
+        PromptSettings prompts = setting.getPromptSettings();
+        if (prompts == null) {
+            prompts = new PromptSettings();
+        }
+        clearer.accept(prompts);
+        setting.setPromptSettings(prompts);
+        userSettingRepository.save(setting);
+    }
+
+    private UserSetting createSettingForUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException("User not found with id: " + userId));
+        UserSetting setting = new UserSetting();
+        setting.setUser(user);
+        return setting;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/PromptTemplateService.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/PromptTemplateService.java
@@ -1,0 +1,243 @@
+package com.example.ainovel.prompt;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+import com.example.ainovel.dto.prompt.PromptTemplateItemDto;
+import com.example.ainovel.dto.prompt.PromptTemplateMetadataResponse;
+import com.example.ainovel.dto.prompt.PromptTemplatesResetRequest;
+import com.example.ainovel.dto.prompt.PromptTemplatesResponse;
+import com.example.ainovel.dto.prompt.PromptTemplatesUpdateRequest;
+import com.example.ainovel.dto.prompt.RefinePromptTemplateDto;
+import com.example.ainovel.dto.prompt.RefinePromptTemplatesUpdateRequest;
+import com.example.ainovel.model.prompt.PromptSettings;
+import com.example.ainovel.model.prompt.RefinePromptSettings;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PromptTemplateService {
+
+    private static final Logger log = LoggerFactory.getLogger(PromptTemplateService.class);
+
+    private final PromptTemplateRepository promptTemplateRepository;
+    private final PromptDefaults promptDefaults;
+    private final TemplateEngine templateEngine;
+    private final PromptTemplateMetadataProvider metadataProvider;
+
+    public PromptTemplatesResponse getEffectiveTemplates(Long userId) {
+        PromptSettings userSettings = userId == null
+                ? null
+                : promptTemplateRepository.findByUserId(userId).orElse(null);
+        return buildResponse(userSettings);
+    }
+
+    public void saveTemplates(Long userId, PromptTemplatesUpdateRequest request) {
+        if (userId == null) {
+            throw new IllegalArgumentException("User id must not be null when saving templates");
+        }
+        PromptSettings settings = promptTemplateRepository.findByUserId(userId)
+                .orElseGet(PromptSettings::new);
+        applyUpdate(settings, request);
+        if (isEmpty(settings)) {
+            promptTemplateRepository.save(userId, null);
+        } else {
+            promptTemplateRepository.save(userId, settings);
+        }
+    }
+
+    public void resetTemplates(Long userId, PromptTemplatesResetRequest request) {
+        if (userId == null) {
+            throw new IllegalArgumentException("User id must not be null when resetting templates");
+        }
+        if (request == null || CollectionUtils.isEmpty(request.getKeys())) {
+            return;
+        }
+        PromptSettings settings = promptTemplateRepository.findByUserId(userId)
+                .orElseGet(PromptSettings::new);
+        boolean changed = false;
+        for (String key : request.getKeys()) {
+            PromptType type = PromptType.fromKey(key);
+            if (type == null) {
+                continue;
+            }
+            changed |= clearTemplate(settings, type);
+        }
+        if (!changed) {
+            return;
+        }
+        if (isEmpty(settings)) {
+            promptTemplateRepository.save(userId, null);
+        } else {
+            promptTemplateRepository.save(userId, settings);
+        }
+    }
+
+    public String render(PromptType type, Long userId, Map<String, Object> context) {
+        String defaultTemplate = getDefaultTemplate(type);
+        if (userId == null) {
+            return renderTemplate(defaultTemplate, context);
+        }
+        PromptSettings settings = promptTemplateRepository.findByUserId(userId).orElse(null);
+        String userTemplate = getUserTemplate(settings, type);
+        if (userTemplate == null) {
+            return renderTemplate(defaultTemplate, context);
+        }
+        try {
+            return renderTemplate(userTemplate, context);
+        } catch (PromptTemplateException ex) {
+            log.warn("Failed to render user template for type {} and user {}. Falling back to default. Error: {}",
+                    type, userId, ex.getMessage());
+            return renderTemplate(defaultTemplate, context);
+        }
+    }
+
+    public String renderWithFallback(PromptType type, Map<String, Object> context) {
+        return renderTemplate(getDefaultTemplate(type), context);
+    }
+
+    public PromptTemplateMetadataResponse getMetadata() {
+        return metadataProvider.getMetadata();
+    }
+
+    private void applyUpdate(PromptSettings settings, PromptTemplatesUpdateRequest request) {
+        if (request == null) {
+            return;
+        }
+        if (request.getStoryCreation() != null) {
+            settings.setStoryCreation(request.getStoryCreation());
+        }
+        if (request.getOutlineChapter() != null) {
+            settings.setOutlineChapter(request.getOutlineChapter());
+        }
+        if (request.getManuscriptSection() != null) {
+            settings.setManuscriptSection(request.getManuscriptSection());
+        }
+        RefinePromptTemplatesUpdateRequest refine = request.getRefine();
+        if (refine != null) {
+            RefinePromptSettings refineSettings = settings.ensureRefine();
+            if (refine.getWithInstruction() != null) {
+                refineSettings.setWithInstruction(refine.getWithInstruction());
+            }
+            if (refine.getWithoutInstruction() != null) {
+                refineSettings.setWithoutInstruction(refine.getWithoutInstruction());
+            }
+        }
+    }
+
+    private boolean clearTemplate(PromptSettings settings, PromptType type) {
+        switch (type) {
+            case STORY_CREATION:
+                if (settings.getStoryCreation() != null) {
+                    settings.setStoryCreation(null);
+                    return true;
+                }
+                return false;
+            case OUTLINE_CHAPTER:
+                if (settings.getOutlineChapter() != null) {
+                    settings.setOutlineChapter(null);
+                    return true;
+                }
+                return false;
+            case MANUSCRIPT_SECTION:
+                if (settings.getManuscriptSection() != null) {
+                    settings.setManuscriptSection(null);
+                    return true;
+                }
+                return false;
+            case REFINE_WITH_INSTRUCTION:
+                if (settings.getRefine() != null && settings.getRefine().getWithInstruction() != null) {
+                    settings.getRefine().setWithInstruction(null);
+                    return true;
+                }
+                return false;
+            case REFINE_WITHOUT_INSTRUCTION:
+                if (settings.getRefine() != null && settings.getRefine().getWithoutInstruction() != null) {
+                    settings.getRefine().setWithoutInstruction(null);
+                    return true;
+                }
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    private PromptTemplatesResponse buildResponse(PromptSettings settings) {
+        PromptTemplatesResponse response = new PromptTemplatesResponse();
+        response.setStoryCreation(buildItem(PromptType.STORY_CREATION, settings));
+        response.setOutlineChapter(buildItem(PromptType.OUTLINE_CHAPTER, settings));
+        response.setManuscriptSection(buildItem(PromptType.MANUSCRIPT_SECTION, settings));
+        RefinePromptTemplateDto refine = new RefinePromptTemplateDto()
+                .setWithInstruction(buildItem(PromptType.REFINE_WITH_INSTRUCTION, settings))
+                .setWithoutInstruction(buildItem(PromptType.REFINE_WITHOUT_INSTRUCTION, settings));
+        response.setRefine(refine);
+        return response;
+    }
+
+    private PromptTemplateItemDto buildItem(PromptType type, PromptSettings settings) {
+        String userTemplate = getUserTemplate(settings, type);
+        String defaultTemplate = getDefaultTemplate(type);
+        boolean isDefault = userTemplate == null;
+        return new PromptTemplateItemDto(isDefault ? defaultTemplate : userTemplate, isDefault);
+    }
+
+    private boolean isEmpty(PromptSettings settings) {
+        if (settings == null) {
+            return true;
+        }
+        boolean baseEmpty = isBlank(settings.getStoryCreation())
+                && isBlank(settings.getOutlineChapter())
+                && isBlank(settings.getManuscriptSection());
+        RefinePromptSettings refine = settings.getRefine();
+        boolean refineEmpty = refine == null
+                || (isBlank(refine.getWithInstruction()) && isBlank(refine.getWithoutInstruction()));
+        if (baseEmpty && refineEmpty) {
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private String getDefaultTemplate(PromptType type) {
+        return switch (type) {
+            case STORY_CREATION -> promptDefaults.getStoryCreation();
+            case OUTLINE_CHAPTER -> promptDefaults.getOutlineChapter();
+            case MANUSCRIPT_SECTION -> promptDefaults.getManuscriptSection();
+            case REFINE_WITH_INSTRUCTION -> promptDefaults.getRefine().getWithInstruction();
+            case REFINE_WITHOUT_INSTRUCTION -> promptDefaults.getRefine().getWithoutInstruction();
+        };
+    }
+
+    private String getUserTemplate(PromptSettings settings, PromptType type) {
+        if (settings == null) {
+            return null;
+        }
+        return switch (type) {
+            case STORY_CREATION -> settings.getStoryCreation();
+            case OUTLINE_CHAPTER -> settings.getOutlineChapter();
+            case MANUSCRIPT_SECTION -> settings.getManuscriptSection();
+            case REFINE_WITH_INSTRUCTION -> settings.getRefine() != null ? settings.getRefine().getWithInstruction() : null;
+            case REFINE_WITHOUT_INSTRUCTION -> settings.getRefine() != null ? settings.getRefine().getWithoutInstruction() : null;
+        };
+    }
+
+    private String renderTemplate(String template, Map<String, Object> context) {
+        try {
+            return templateEngine.render(template, context);
+        } catch (PromptTemplateException ex) {
+            throw ex;
+        } catch (RuntimeException ex) {
+            throw new PromptTemplateException("Failed to render prompt template", ex);
+        }
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/PromptType.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/PromptType.java
@@ -1,0 +1,32 @@
+package com.example.ainovel.prompt;
+
+public enum PromptType {
+    STORY_CREATION("storyCreation"),
+    OUTLINE_CHAPTER("outlineChapter"),
+    MANUSCRIPT_SECTION("manuscriptSection"),
+    REFINE_WITH_INSTRUCTION("refine.withInstruction"),
+    REFINE_WITHOUT_INSTRUCTION("refine.withoutInstruction");
+
+    private final String key;
+
+    PromptType(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public static PromptType fromKey(String key) {
+        if (key == null) {
+            return null;
+        }
+        String normalized = key.trim();
+        for (PromptType type : values()) {
+            if (type.key.equalsIgnoreCase(normalized)) {
+                return type;
+            }
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/RefinePromptDefaults.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/RefinePromptDefaults.java
@@ -1,0 +1,35 @@
+package com.example.ainovel.prompt;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RefinePromptDefaults {
+
+    private String withInstruction;
+    private String withoutInstruction;
+
+    public String getWithInstruction() {
+        return withInstruction;
+    }
+
+    public void setWithInstruction(String withInstruction) {
+        this.withInstruction = withInstruction;
+    }
+
+    public String getWithoutInstruction() {
+        return withoutInstruction;
+    }
+
+    public void setWithoutInstruction(String withoutInstruction) {
+        this.withoutInstruction = withoutInstruction;
+    }
+
+    public void validate() {
+        if (withInstruction == null || withInstruction.isBlank()) {
+            throw new IllegalStateException("Default refine-with-instruction prompt must not be empty");
+        }
+        if (withoutInstruction == null || withoutInstruction.isBlank()) {
+            throw new IllegalStateException("Default refine-without-instruction prompt must not be empty");
+        }
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/TemplateEngine.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/TemplateEngine.java
@@ -1,0 +1,493 @@
+package com.example.ainovel.prompt;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeanWrapperImpl;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class TemplateEngine {
+
+    private static final Pattern EXPRESSION_PATTERN = Pattern.compile("\\$\\{([^{}]+)}");
+    private static final String ESCAPED_SEQUENCE = "__PROMPT_TEMPLATE_ESCAPED__";
+
+    private final ObjectMapper objectMapper;
+
+    public TemplateEngine(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public String render(String template, Map<String, Object> context) {
+        if (template == null) {
+            return "";
+        }
+        Map<String, Object> safeContext = context == null ? Collections.emptyMap() : context;
+        String prepared = template.replace("$${", ESCAPED_SEQUENCE + "{");
+        Matcher matcher = EXPRESSION_PATTERN.matcher(prepared);
+        StringBuffer buffer = new StringBuffer();
+        while (matcher.find()) {
+            String expression = matcher.group(1).trim();
+            ValueWrapper value = evaluateExpression(expression, safeContext);
+            String replacement = value.toFinalString();
+            matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(buffer);
+        return buffer.toString().replace(ESCAPED_SEQUENCE + "{", "${");
+    }
+
+    private ValueWrapper evaluateExpression(String expression, Map<String, Object> context) {
+        if (!StringUtils.hasText(expression)) {
+            return ValueWrapper.empty();
+        }
+        List<String> segments = splitPipeline(expression);
+        if (segments.isEmpty()) {
+            return ValueWrapper.empty();
+        }
+        ValueWrapper value = resolvePath(segments.get(0).trim(), context);
+        for (int i = 1; i < segments.size(); i++) {
+            String segment = segments.get(i).trim();
+            if (segment.isEmpty()) {
+                continue;
+            }
+            value = applyFunction(value, segment);
+        }
+        return value;
+    }
+
+    private ValueWrapper resolvePath(String pathExpression, Map<String, Object> context) {
+        if (!StringUtils.hasText(pathExpression)) {
+            return ValueWrapper.empty();
+        }
+        List<PathToken> tokens = parsePath(pathExpression);
+        List<Object> current = new ArrayList<>();
+        current.add(context);
+        boolean starEncountered = false;
+        for (PathToken token : tokens) {
+            List<Object> next = new ArrayList<>();
+            for (Object value : current) {
+                Object propertyValue = extractPropertyValue(value, token.name());
+                List<Object> intermediate = new ArrayList<>();
+                intermediate.add(propertyValue);
+                for (IndexToken index : token.indices()) {
+                    if (index.star()) {
+                        starEncountered = true;
+                        List<Object> expanded = new ArrayList<>();
+                        for (Object item : intermediate) {
+                            if (item == null) {
+                                continue;
+                            }
+                            if (item instanceof Iterable<?> iterable) {
+                                for (Object element : iterable) {
+                                    if (element != null) {
+                                        expanded.add(element);
+                                    }
+                                }
+                            } else if (item.getClass().isArray()) {
+                                int length = Array.getLength(item);
+                                for (int i = 0; i < length; i++) {
+                                    Object element = Array.get(item, i);
+                                    if (element != null) {
+                                        expanded.add(element);
+                                    }
+                                }
+                            }
+                        }
+                        intermediate = expanded;
+                    } else {
+                        int idx = index.index();
+                        List<Object> selected = new ArrayList<>();
+                        for (Object item : intermediate) {
+                            if (item == null) {
+                                selected.add(null);
+                            } else if (item instanceof List<?> list) {
+                                selected.add(idx >= 0 && idx < list.size() ? list.get(idx) : null);
+                            } else if (item.getClass().isArray()) {
+                                int length = Array.getLength(item);
+                                selected.add(idx >= 0 && idx < length ? Array.get(item, idx) : null);
+                            } else {
+                                selected.add(null);
+                            }
+                        }
+                        intermediate = selected;
+                    }
+                }
+                next.addAll(intermediate);
+            }
+            current = next;
+        }
+        if (current.isEmpty()) {
+            return ValueWrapper.empty(starEncountered);
+        }
+        if (current.size() == 1 && !starEncountered) {
+            return ValueWrapper.of(current.get(0));
+        }
+        return ValueWrapper.ofList(current, starEncountered ? "、" : ", ");
+    }
+
+    private Object extractPropertyValue(Object value, String propertyName) {
+        if (value == null) {
+            return null;
+        }
+        if (!StringUtils.hasText(propertyName)) {
+            return value;
+        }
+        if (value instanceof Map<?, ?> map) {
+            return map.get(propertyName);
+        }
+        if (value instanceof List<?> list && isNumeric(propertyName)) {
+            int index = Integer.parseInt(propertyName);
+            return index >= 0 && index < list.size() ? list.get(index) : null;
+        }
+        if (value.getClass().isArray() && isNumeric(propertyName)) {
+            int index = Integer.parseInt(propertyName);
+            int length = Array.getLength(value);
+            return index >= 0 && index < length ? Array.get(value, index) : null;
+        }
+        try {
+            BeanWrapper wrapper = new BeanWrapperImpl(value);
+            if (wrapper.isReadableProperty(propertyName)) {
+                return wrapper.getPropertyValue(propertyName);
+            }
+        } catch (Exception ignored) {
+            // Ignore access issues and fall back to null
+        }
+        return null;
+    }
+
+    private ValueWrapper applyFunction(ValueWrapper current, String functionSegment) {
+        int parenIndex = functionSegment.indexOf('(');
+        String name;
+        String argsSection;
+        if (parenIndex < 0) {
+            name = functionSegment.trim();
+            argsSection = "";
+        } else {
+            name = functionSegment.substring(0, parenIndex).trim();
+            int endIndex = functionSegment.lastIndexOf(')');
+            if (endIndex < parenIndex) {
+                throw new PromptTemplateException("Malformed function expression: " + functionSegment);
+            }
+            argsSection = functionSegment.substring(parenIndex + 1, endIndex);
+        }
+        List<String> args = parseArguments(argsSection);
+        return switch (name) {
+            case "default" -> applyDefault(current, args);
+            case "join" -> applyJoin(current, args);
+            case "upper" -> ValueWrapper.of(current.asString().toUpperCase(Locale.ROOT));
+            case "lower" -> ValueWrapper.of(current.asString().toLowerCase(Locale.ROOT));
+            case "trim" -> ValueWrapper.of(current.asString().trim());
+            case "json" -> applyJson(current);
+            case "" -> current;
+            default -> throw new PromptTemplateException("Unknown function: " + name);
+        };
+    }
+
+    private ValueWrapper applyDefault(ValueWrapper current, List<String> args) {
+        if (args.isEmpty()) {
+            throw new PromptTemplateException("default() requires an argument");
+        }
+        String fallback = args.get(0);
+        String value = current.asString();
+        if (!StringUtils.hasText(value)) {
+            return ValueWrapper.of(fallback);
+        }
+        return ValueWrapper.of(value);
+    }
+
+    private ValueWrapper applyJoin(ValueWrapper current, List<String> args) {
+        List<Object> list = current.asList();
+        String separator = args.isEmpty() ? current.defaultSeparator() : args.get(0);
+        String joined = list.stream()
+                .map(this::stringify)
+                .filter(Objects::nonNull)
+                .collect(java.util.stream.Collectors.joining(separator));
+        return ValueWrapper.of(joined);
+    }
+
+    private ValueWrapper applyJson(ValueWrapper current) {
+        try {
+            return ValueWrapper.of(objectMapper.writeValueAsString(current.rawValue()));
+        } catch (JsonProcessingException e) {
+            throw new PromptTemplateException("Failed to serialize value as JSON", e);
+        }
+    }
+
+    private List<String> splitPipeline(String expression) {
+        List<String> segments = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        char quoteChar = '\0';
+        int parentheses = 0;
+        for (int i = 0; i < expression.length(); i++) {
+            char ch = expression.charAt(i);
+            if ((ch == '\'' || ch == '"')) {
+                if (inQuotes && ch == quoteChar) {
+                    inQuotes = false;
+                } else if (!inQuotes) {
+                    inQuotes = true;
+                    quoteChar = ch;
+                }
+            } else if (!inQuotes) {
+                if (ch == '(') {
+                    parentheses++;
+                } else if (ch == ')' && parentheses > 0) {
+                    parentheses--;
+                } else if (ch == '|' && parentheses == 0) {
+                    segments.add(current.toString());
+                    current.setLength(0);
+                    continue;
+                }
+            }
+            current.append(ch);
+        }
+        if (current.length() > 0) {
+            segments.add(current.toString());
+        }
+        return segments;
+    }
+
+    private List<PathToken> parsePath(String expression) {
+        List<PathToken> tokens = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        int bracketDepth = 0;
+        for (int i = 0; i < expression.length(); i++) {
+            char ch = expression.charAt(i);
+            if (ch == '.' && bracketDepth == 0) {
+                tokens.add(parseSegment(current.toString()));
+                current.setLength(0);
+                continue;
+            }
+            if (ch == '[') {
+                bracketDepth++;
+            } else if (ch == ']') {
+                bracketDepth = Math.max(0, bracketDepth - 1);
+            }
+            current.append(ch);
+        }
+        if (current.length() > 0) {
+            tokens.add(parseSegment(current.toString()));
+        }
+        if (tokens.isEmpty()) {
+            throw new PromptTemplateException("Invalid path expression: " + expression);
+        }
+        return tokens;
+    }
+
+    private PathToken parseSegment(String segment) {
+        String trimmed = segment.trim();
+        if (trimmed.isEmpty()) {
+            return new PathToken("", List.of());
+        }
+        List<IndexToken> indices = new ArrayList<>();
+        String name = trimmed;
+        int bracketIndex = trimmed.indexOf('[');
+        if (bracketIndex >= 0) {
+            name = trimmed.substring(0, bracketIndex).trim();
+            int cursor = bracketIndex;
+            while (cursor >= 0 && cursor < trimmed.length()) {
+                int close = trimmed.indexOf(']', cursor);
+                if (close < 0) {
+                    throw new PromptTemplateException("Unclosed index segment in: " + segment);
+                }
+                String inside = trimmed.substring(cursor + 1, close).trim();
+                if ("*".equals(inside)) {
+                    indices.add(IndexToken.star());
+                } else if (!inside.isEmpty()) {
+                    if (!isNumeric(inside)) {
+                        throw new PromptTemplateException("Invalid index: " + inside);
+                    }
+                    indices.add(IndexToken.of(Integer.parseInt(inside)));
+                } else {
+                    throw new PromptTemplateException("Index cannot be empty: " + segment);
+                }
+                cursor = trimmed.indexOf('[', close);
+            }
+        }
+        return new PathToken(name, indices);
+    }
+
+    private List<String> parseArguments(String argsSection) {
+        if (!StringUtils.hasText(argsSection)) {
+            return Collections.emptyList();
+        }
+        List<String> args = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        char quoteChar = '\0';
+        int parentheses = 0;
+        for (int i = 0; i < argsSection.length(); i++) {
+            char ch = argsSection.charAt(i);
+            if ((ch == '\'' || ch == '"')) {
+                if (inQuotes && ch == quoteChar) {
+                    inQuotes = false;
+                } else if (!inQuotes) {
+                    inQuotes = true;
+                    quoteChar = ch;
+                }
+            } else if (!inQuotes) {
+                if (ch == '(') {
+                    parentheses++;
+                } else if (ch == ')' && parentheses > 0) {
+                    parentheses--;
+                } else if (ch == ',' && parentheses == 0) {
+                    args.add(stripQuotes(current.toString().trim()));
+                    current.setLength(0);
+                    continue;
+                }
+            }
+            current.append(ch);
+        }
+        if (current.length() > 0) {
+            args.add(stripQuotes(current.toString().trim()));
+        }
+        return args;
+    }
+
+    private String stripQuotes(String value) {
+        if (value == null || value.length() < 2) {
+            return value;
+        }
+        if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    private boolean isNumeric(String text) {
+        if (!StringUtils.hasText(text)) {
+            return false;
+        }
+        for (int i = 0; i < text.length(); i++) {
+            if (!Character.isDigit(text.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String stringify(Object value) {
+        if (value == null) {
+            return "";
+        }
+        if (value instanceof String str) {
+            return str;
+        }
+        if (value instanceof Collection<?> collection) {
+            return collection.stream().map(this::stringify).collect(java.util.stream.Collectors.joining(", "));
+        }
+        return String.valueOf(value);
+    }
+
+    private record PathToken(String name, List<IndexToken> indices) {
+    }
+
+    private record IndexToken(boolean star, int index) {
+        static IndexToken star() {
+            return new IndexToken(true, -1);
+        }
+
+        static IndexToken of(int index) {
+            return new IndexToken(false, index);
+        }
+    }
+
+    private static final class ValueWrapper {
+        private final Object value;
+        private final boolean listLike;
+        private final String defaultSeparator;
+
+        private ValueWrapper(Object value, boolean listLike, String defaultSeparator) {
+            this.value = value;
+            this.listLike = listLike;
+            this.defaultSeparator = defaultSeparator;
+        }
+
+        static ValueWrapper of(Object value) {
+            return new ValueWrapper(value, false, "、");
+        }
+
+        static ValueWrapper ofList(List<Object> values, String defaultSeparator) {
+            return new ValueWrapper(values, true, defaultSeparator);
+        }
+
+        static ValueWrapper empty() {
+            return new ValueWrapper("", false, "、");
+        }
+
+        static ValueWrapper empty(boolean asList) {
+            if (asList) {
+                return new ValueWrapper(new ArrayList<>(), true, "、");
+            }
+            return empty();
+        }
+
+        Object rawValue() {
+            return value;
+        }
+
+        String defaultSeparator() {
+            return defaultSeparator;
+        }
+
+        List<Object> asList() {
+            if (value == null) {
+                return new ArrayList<>();
+            }
+            if (listLike && value instanceof List<?> list) {
+                return new ArrayList<>(list);
+            }
+            if (value instanceof List<?> list) {
+                return new ArrayList<>(list);
+            }
+            if (value instanceof Collection<?> collection) {
+                return new ArrayList<>(collection);
+            }
+            if (value != null && value.getClass().isArray()) {
+                int length = Array.getLength(value);
+                List<Object> result = new ArrayList<>(length);
+                for (int i = 0; i < length; i++) {
+                    result.add(Array.get(value, i));
+                }
+                return result;
+            }
+            List<Object> single = new ArrayList<>();
+            single.add(value);
+            return single;
+        }
+
+        String asString() {
+            return toFinalString();
+        }
+
+        String toFinalString() {
+            if (value == null) {
+                return "";
+            }
+            if (listLike) {
+                return asList().stream()
+                        .map(item -> item == null ? "" : item.toString())
+                        .collect(java.util.stream.Collectors.joining(defaultSeparator));
+            }
+            if (value instanceof Collection<?> collection) {
+                return collection.stream()
+                        .map(item -> item == null ? "" : item.toString())
+                        .collect(java.util.stream.Collectors.joining(defaultSeparator));
+            }
+            return String.valueOf(value);
+        }
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/context/ManuscriptPromptContextBuilder.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/context/ManuscriptPromptContextBuilder.java
@@ -1,0 +1,344 @@
+package com.example.ainovel.prompt.context;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.example.ainovel.dto.RelationshipChangeDto;
+import com.example.ainovel.model.CharacterCard;
+import com.example.ainovel.model.CharacterChangeLog;
+import com.example.ainovel.model.OutlineCard;
+import com.example.ainovel.model.OutlineChapter;
+import com.example.ainovel.model.OutlineScene;
+import com.example.ainovel.model.SceneCharacter;
+import com.example.ainovel.model.StoryCard;
+import com.example.ainovel.model.TemporaryCharacter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ManuscriptPromptContextBuilder {
+
+    private final ObjectMapper objectMapper;
+
+    public Map<String, Object> build(
+            OutlineScene scene,
+            StoryCard story,
+            List<CharacterCard> allCharacters,
+            List<SceneCharacter> sceneCharacters,
+            List<TemporaryCharacter> temporaryCharacters,
+            String previousSectionContent,
+            List<OutlineScene> previousChapterOutline,
+            List<OutlineScene> currentChapterOutline,
+            int chapterNumber,
+            int totalChapters,
+            int sceneNumber,
+            int totalScenesInChapter,
+            Map<Long, CharacterChangeLog> latestCharacterLogs
+    ) {
+        Map<String, Object> root = new LinkedHashMap<>();
+
+        Map<String, Object> storyMap = new LinkedHashMap<>();
+        storyMap.put("title", safeString(story.getTitle()));
+        storyMap.put("genre", safeString(story.getGenre()));
+        storyMap.put("tone", safeString(story.getTone()));
+        storyMap.put("synopsis", safeString(story.getSynopsis()));
+        root.put("story", storyMap);
+
+        OutlineChapter outlineChapter = scene.getOutlineChapter();
+        OutlineCard outline = outlineChapter != null ? outlineChapter.getOutlineCard() : null;
+        Map<String, Object> outlineMap = new LinkedHashMap<>();
+        outlineMap.put("pointOfView", outline != null ? safeString(outline.getPointOfView()) : "第三人称有限视角");
+        outlineMap.put("title", outline != null ? safeString(outline.getTitle()) : "");
+        root.put("outline", outlineMap);
+
+        Map<String, Object> chapter = new LinkedHashMap<>();
+        chapter.put("number", chapterNumber);
+        chapter.put("total", totalChapters);
+        chapter.put("title", outlineChapter != null ? safeString(outlineChapter.getTitle()) : "");
+        root.put("chapter", chapter);
+
+        Map<String, Object> sceneMap = new LinkedHashMap<>();
+        sceneMap.put("number", sceneNumber);
+        sceneMap.put("totalInChapter", totalScenesInChapter);
+        sceneMap.put("synopsis", safeString(scene.getSynopsis()));
+        sceneMap.put("expectedWords", scene.getExpectedWords() != null ? scene.getExpectedWords() : 1200);
+        sceneMap.put("coreCharacters", toSceneCharacterMaps(sceneCharacters));
+        sceneMap.put("coreCharacterSummary", formatSceneCharacters(sceneCharacters));
+        sceneMap.put("temporaryCharacters", toTemporaryCharacterMaps(temporaryCharacters));
+        sceneMap.put("temporaryCharacterSummary", formatTemporaryCharacters(temporaryCharacters));
+        sceneMap.put("presentCharacters", formatPresentCharacters(sceneCharacters, scene.getPresentCharacters()));
+        root.put("scene", sceneMap);
+
+        Map<String, Object> charactersMap = new LinkedHashMap<>();
+        charactersMap.put("all", toCharacterMaps(allCharacters));
+        charactersMap.put("allSummary", formatCharacters(allCharacters, latestCharacterLogs));
+        charactersMap.put("present", extractPresentCharacters(sceneCharacters, scene.getPresentCharacters()));
+        root.put("characters", charactersMap);
+
+        Map<String, Object> previousSection = new LinkedHashMap<>();
+        previousSection.put("content", previousSectionContent == null ? "无" : previousSectionContent);
+        root.put("previousSection", previousSection);
+
+        Map<String, Object> previousChapter = new LinkedHashMap<>();
+        previousChapter.put("scenes", toOutlineSceneMaps(previousChapterOutline));
+        previousChapter.put("summary", formatOutlineScenes(previousChapterOutline));
+        root.put("previousChapter", previousChapter);
+
+        Map<String, Object> currentChapter = new LinkedHashMap<>();
+        currentChapter.put("scenes", toOutlineSceneMaps(currentChapterOutline));
+        currentChapter.put("summary", formatOutlineScenes(currentChapterOutline));
+        root.put("currentChapter", currentChapter);
+
+        Map<String, Object> logMap = new LinkedHashMap<>();
+        logMap.put("latestByCharacter", buildLatestLogMap(latestCharacterLogs));
+        root.put("log", logMap);
+
+        return root;
+    }
+
+    private List<Map<String, Object>> toCharacterMaps(List<CharacterCard> characters) {
+        if (characters == null) {
+            return List.of();
+        }
+        return characters.stream()
+                .map(character -> {
+                    Map<String, Object> map = new LinkedHashMap<>();
+                    map.put("id", character.getId());
+                    map.put("name", safeString(character.getName()));
+                    map.put("synopsis", safeString(character.getSynopsis()));
+                    map.put("details", safeString(character.getDetails()));
+                    map.put("relationships", safeString(character.getRelationships()));
+                    return map;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<Map<String, Object>> toSceneCharacterMaps(List<SceneCharacter> sceneCharacters) {
+        if (sceneCharacters == null) {
+            return List.of();
+        }
+        return sceneCharacters.stream()
+                .map(sc -> {
+                    Map<String, Object> map = new LinkedHashMap<>();
+                    map.put("characterName", safeString(sc.getCharacterName()));
+                    map.put("status", safeString(sc.getStatus()));
+                    map.put("thought", safeString(sc.getThought()));
+                    map.put("action", safeString(sc.getAction()));
+                    return map;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<Map<String, Object>> toTemporaryCharacterMaps(List<TemporaryCharacter> temporaryCharacters) {
+        if (temporaryCharacters == null) {
+            return List.of();
+        }
+        return temporaryCharacters.stream()
+                .map(tc -> {
+                    Map<String, Object> map = new LinkedHashMap<>();
+                    map.put("name", safeString(tc.getName()));
+                    map.put("summary", safeString(tc.getSummary()));
+                    map.put("details", safeString(tc.getDetails()));
+                    map.put("relationships", safeString(tc.getRelationships()));
+                    map.put("status", safeString(tc.getStatus()));
+                    map.put("thought", safeString(tc.getThought()));
+                    map.put("action", safeString(tc.getAction()));
+                    return map;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<Map<String, Object>> toOutlineSceneMaps(List<OutlineScene> scenes) {
+        if (scenes == null) {
+            return List.of();
+        }
+        return scenes.stream()
+                .map(scene -> {
+                    Map<String, Object> map = new LinkedHashMap<>();
+                    map.put("sceneNumber", scene.getSceneNumber());
+                    map.put("synopsis", safeString(scene.getSynopsis()));
+                    map.put("presentCharacters", safeString(scene.getPresentCharacters()));
+                    map.put("expectedWords", scene.getExpectedWords());
+                    return map;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<String> extractPresentCharacters(List<SceneCharacter> sceneCharacters, String fallback) {
+        if (sceneCharacters != null && !sceneCharacters.isEmpty()) {
+            LinkedHashSet<String> names = sceneCharacters.stream()
+                    .map(SceneCharacter::getCharacterName)
+                    .filter(name -> name != null && !name.isBlank())
+                    .map(String::trim)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            if (!names.isEmpty()) {
+                return new ArrayList<>(names);
+            }
+        }
+        if (fallback == null || fallback.isBlank()) {
+            return List.of();
+        }
+        String[] parts = fallback.split(",|，|、");
+        List<String> results = new ArrayList<>();
+        for (String part : parts) {
+            String trimmed = part.trim();
+            if (!trimmed.isEmpty()) {
+                results.add(trimmed);
+            }
+        }
+        return results;
+    }
+
+    private Map<String, String> buildLatestLogMap(Map<Long, CharacterChangeLog> latestLogs) {
+        if (latestLogs == null || latestLogs.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> result = new LinkedHashMap<>();
+        latestLogs.forEach((id, log) -> {
+            if (log == null) {
+                return;
+            }
+            String name = log.getCharacter() != null ? safeString(log.getCharacter().getName()) : String.valueOf(id);
+            result.put(name == null || name.isBlank() ? String.valueOf(id) : name, summarizeCharacterGrowth(log));
+        });
+        return result;
+    }
+
+    private String formatCharacters(List<CharacterCard> allCharacters, Map<Long, CharacterChangeLog> latestLogs) {
+        if (allCharacters == null || allCharacters.isEmpty()) {
+            return "无";
+        }
+        return allCharacters.stream()
+                .map(c -> String.format(
+                        "- %s\n  - 概述: %s\n  - 详细背景: %s\n  - 关系: %s\n  - 最近成长轨迹: %s\n  - 最新关系图谱: %s",
+                        safeString(c.getName()),
+                        nullToNA(c.getSynopsis()),
+                        nullToNA(c.getDetails()),
+                        nullToNA(c.getRelationships()),
+                        summarizeCharacterGrowth(latestLogs != null ? latestLogs.get(c.getId()) : null),
+                        summarizeRelationshipMap(latestLogs != null ? latestLogs.get(c.getId()) : null)
+                ))
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String formatOutlineScenes(List<OutlineScene> scenes) {
+        if (scenes == null || scenes.isEmpty()) {
+            return "无";
+        }
+        return scenes.stream()
+                .map(sc -> String.format(
+                        "第 %d 节:\n- 梗概: %s\n- 核心出场人物: %s\n- 核心人物状态卡:\n%s\n- 临时人物:\n%s",
+                        sc.getSceneNumber(),
+                        nullToNA(sc.getSynopsis()),
+                        nullToNA(formatPresentCharacters(sc.getSceneCharacters(), sc.getPresentCharacters())),
+                        formatSceneCharacters(sc.getSceneCharacters()),
+                        formatTemporaryCharacters(sc.getTemporaryCharacters())
+                ))
+                .collect(Collectors.joining("\n\n"));
+    }
+
+    private String formatTemporaryCharacters(List<TemporaryCharacter> temporaryCharacters) {
+        if (temporaryCharacters == null || temporaryCharacters.isEmpty()) {
+            return "无";
+        }
+        return temporaryCharacters.stream()
+                .map(tc -> String.format(
+                        "- %s\n  - 概要: %s\n  - 详情: %s\n  - 关系: %s\n  - 在本节中的状态: %s\n  - 在本节中的想法: %s\n  - 在本节中的行动: %s",
+                        safeString(tc.getName()),
+                        nullToNA(tc.getSummary()),
+                        nullToNA(tc.getDetails()),
+                        nullToNA(tc.getRelationships()),
+                        nullToNA(tc.getStatus()),
+                        nullToNA(tc.getThought()),
+                        nullToNA(tc.getAction())
+                ))
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String formatSceneCharacters(List<SceneCharacter> sceneCharacters) {
+        if (sceneCharacters == null || sceneCharacters.isEmpty()) {
+            return "无";
+        }
+        return sceneCharacters.stream()
+                .map(sc -> String.format(
+                        "- %s\n  - 状态: %s\n  - 想法: %s\n  - 行动: %s",
+                        safeString(sc.getCharacterName()).isEmpty() ? "未知角色" : safeString(sc.getCharacterName()),
+                        nullToNA(sc.getStatus()),
+                        nullToNA(sc.getThought()),
+                        nullToNA(sc.getAction())
+                ))
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String formatPresentCharacters(List<SceneCharacter> sceneCharacters, String fallback) {
+        List<String> names = extractPresentCharacters(sceneCharacters, fallback);
+        if (names.isEmpty()) {
+            return fallback == null ? "" : fallback;
+        }
+        return String.join(", ", names);
+    }
+
+    private String summarizeCharacterGrowth(CharacterChangeLog log) {
+        if (log == null) {
+            return "暂无最新变化记录";
+        }
+        String combined = java.util.stream.Stream.of(log.getCharacterChanges(), log.getNewlyKnownInfo())
+                .filter(text -> text != null && !text.isBlank())
+                .map(String::trim)
+                .collect(Collectors.joining(" / "));
+        if (combined == null || combined.isBlank()) {
+            combined = nullToNA(log.getCharacterDetailsAfter());
+        }
+        return nullToNA(combined);
+    }
+
+    private String summarizeRelationshipMap(CharacterChangeLog log) {
+        if (log == null || log.getRelationshipChangesJson() == null || log.getRelationshipChangesJson().isBlank()) {
+            return "暂无新的关系变更";
+        }
+        try {
+            RelationshipChangeDto[] changes = objectMapper.readValue(
+                    log.getRelationshipChangesJson(),
+                    RelationshipChangeDto[].class
+            );
+            if (changes.length == 0) {
+                return "暂无新的关系变更";
+            }
+            return Arrays.stream(changes)
+                    .map(change -> String.format(
+                            "与角色ID %d: %s -> %s（原因: %s）",
+                            change.getTargetCharacterId(),
+                            defaultString(change.getPreviousRelationship(), "未知"),
+                            defaultString(change.getCurrentRelationship(), "未知"),
+                            defaultString(change.getChangeReason(), "未说明")
+                    ))
+                    .collect(Collectors.joining("；"));
+        } catch (Exception e) {
+            return "暂无新的关系变更";
+        }
+    }
+
+    private String nullToNA(String value) {
+        String trimmed = safeString(value);
+        return trimmed.isEmpty() ? "无" : trimmed;
+    }
+
+    private String defaultString(String value, String fallback) {
+        String trimmed = safeString(value);
+        return trimmed.isEmpty() ? fallback : trimmed;
+    }
+
+    private String safeString(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/context/OutlinePromptContextBuilder.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/context/OutlinePromptContextBuilder.java
@@ -1,0 +1,79 @@
+package com.example.ainovel.prompt.context;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.example.ainovel.dto.GenerateChapterRequest;
+import com.example.ainovel.model.CharacterCard;
+import com.example.ainovel.model.OutlineCard;
+import com.example.ainovel.model.StoryCard;
+
+@Component
+public class OutlinePromptContextBuilder {
+
+    public Map<String, Object> build(StoryCard storyCard, OutlineCard outlineCard,
+                                     GenerateChapterRequest request, String previousChapterSynopsis) {
+        Map<String, Object> root = new LinkedHashMap<>();
+        Map<String, Object> story = new LinkedHashMap<>();
+        story.put("title", safeString(storyCard.getTitle()));
+        story.put("synopsis", safeString(storyCard.getSynopsis()));
+        story.put("genre", safeString(storyCard.getGenre()));
+        story.put("tone", safeString(storyCard.getTone()));
+        story.put("storyArc", safeString(storyCard.getStoryArc()));
+        root.put("story", story);
+
+        Map<String, Object> outline = new LinkedHashMap<>();
+        outline.put("title", safeString(outlineCard.getTitle()));
+        outline.put("pointOfView", safeString(outlineCard.getPointOfView()));
+        root.put("outline", outline);
+
+        Map<String, Object> chapter = new LinkedHashMap<>();
+        chapter.put("number", request.getChapterNumber());
+        chapter.put("sectionsPerChapter", request.getSectionsPerChapter());
+        chapter.put("wordsPerSection", request.getWordsPerSection());
+        chapter.put("previousSynopsis", previousChapterSynopsis);
+        root.put("chapter", chapter);
+
+        List<CharacterCard> characters = storyCard.getCharacters() == null ? List.of() : storyCard.getCharacters();
+        List<Map<String, Object>> characterList = characters.stream()
+                .map(this::toCharacterMap)
+                .collect(Collectors.toList());
+        List<String> characterNames = characters.stream()
+                .map(CharacterCard::getName)
+                .filter(name -> name != null && !name.isBlank())
+                .map(String::trim)
+                .collect(Collectors.toList());
+        String characterSummary = characters.isEmpty()
+                ? "无角色信息。"
+                : characters.stream()
+                        .map(c -> "- " + safeString(c.getName()) + ": " + safeString(c.getSynopsis()))
+                        .collect(Collectors.joining("\n"));
+
+        Map<String, Object> characterContext = new LinkedHashMap<>();
+        characterContext.put("list", characterList);
+        characterContext.put("names", characterNames);
+        characterContext.put("summary", characterSummary);
+        root.put("characters", characterContext);
+
+        root.put("request", Map.of("raw", request));
+        return root;
+    }
+
+    private Map<String, Object> toCharacterMap(CharacterCard card) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("id", card.getId());
+        map.put("name", safeString(card.getName()));
+        map.put("synopsis", safeString(card.getSynopsis()));
+        map.put("details", safeString(card.getDetails()));
+        map.put("relationships", safeString(card.getRelationships()));
+        return map;
+    }
+
+    private String safeString(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/context/PromptContextFactory.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/context/PromptContextFactory.java
@@ -1,0 +1,74 @@
+package com.example.ainovel.prompt.context;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.example.ainovel.dto.ConceptionRequest;
+import com.example.ainovel.dto.GenerateChapterRequest;
+import com.example.ainovel.dto.RefineRequest;
+import com.example.ainovel.model.CharacterCard;
+import com.example.ainovel.model.CharacterChangeLog;
+import com.example.ainovel.model.OutlineCard;
+import com.example.ainovel.model.OutlineScene;
+import com.example.ainovel.model.SceneCharacter;
+import com.example.ainovel.model.StoryCard;
+import com.example.ainovel.model.TemporaryCharacter;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PromptContextFactory {
+
+    private final StoryPromptContextBuilder storyPromptContextBuilder;
+    private final OutlinePromptContextBuilder outlinePromptContextBuilder;
+    private final ManuscriptPromptContextBuilder manuscriptPromptContextBuilder;
+    private final RefinePromptContextBuilder refinePromptContextBuilder;
+
+    public Map<String, Object> buildStoryCreationContext(ConceptionRequest request) {
+        return storyPromptContextBuilder.build(request);
+    }
+
+    public Map<String, Object> buildOutlineChapterContext(StoryCard storyCard, OutlineCard outlineCard,
+                                                          GenerateChapterRequest request, String previousChapterSynopsis) {
+        return outlinePromptContextBuilder.build(storyCard, outlineCard, request, previousChapterSynopsis);
+    }
+
+    public Map<String, Object> buildManuscriptSectionContext(
+            OutlineScene scene,
+            StoryCard story,
+            List<CharacterCard> allCharacters,
+            List<SceneCharacter> sceneCharacters,
+            List<TemporaryCharacter> temporaryCharacters,
+            String previousSectionContent,
+            List<OutlineScene> previousChapterOutline,
+            List<OutlineScene> currentChapterOutline,
+            int chapterNumber,
+            int totalChapters,
+            int sceneNumber,
+            int totalScenesInChapter,
+            Map<Long, CharacterChangeLog> latestCharacterLogs
+    ) {
+        return manuscriptPromptContextBuilder.build(
+                scene,
+                story,
+                allCharacters,
+                sceneCharacters,
+                temporaryCharacters,
+                previousSectionContent,
+                previousChapterOutline,
+                currentChapterOutline,
+                chapterNumber,
+                totalChapters,
+                sceneNumber,
+                totalScenesInChapter,
+                latestCharacterLogs
+        );
+    }
+
+    public Map<String, Object> buildRefineContext(RefineRequest request) {
+        return refinePromptContextBuilder.build(request);
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/context/RefinePromptContextBuilder.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/context/RefinePromptContextBuilder.java
@@ -1,0 +1,37 @@
+package com.example.ainovel.prompt.context;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.example.ainovel.dto.RefineRequest;
+
+@Component
+public class RefinePromptContextBuilder {
+
+    public Map<String, Object> build(RefineRequest request) {
+        Map<String, Object> root = new LinkedHashMap<>();
+        String contextType = safeTrim(request.getContextType());
+        String note = contextType == null ? "" : String.format("这是一个关于“%s”的文本。\n", contextType);
+
+        root.put("text", request.getText());
+        root.put("instruction", request.getInstruction());
+        root.put("contextType", contextType == null ? "" : contextType);
+
+        Map<String, Object> context = new LinkedHashMap<>();
+        context.put("note", note);
+        root.put("context", context);
+
+        root.put("request", Map.of("raw", request));
+        return root;
+    }
+
+    private String safeTrim(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/prompt/context/StoryPromptContextBuilder.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/context/StoryPromptContextBuilder.java
@@ -1,0 +1,87 @@
+package com.example.ainovel.prompt.context;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.example.ainovel.dto.ConceptionRequest;
+
+@Component
+public class StoryPromptContextBuilder {
+
+    public Map<String, Object> build(ConceptionRequest request) {
+        Map<String, Object> root = new LinkedHashMap<>();
+        String idea = safeTrim(request.getIdea());
+        String genre = safeTrim(request.getGenre());
+        String tone = safeTrim(request.getTone());
+
+        List<String> tags = request.getTags() == null ? List.of() : request.getTags().stream()
+                .filter(tag -> tag != null && !tag.isBlank())
+                .map(String::trim)
+                .collect(Collectors.toCollection(java.util.LinkedHashSet::new))
+                .stream()
+                .collect(Collectors.toList());
+
+        StringBuilder summaryBuilder = new StringBuilder();
+        Map<String, String> lines = new LinkedHashMap<>();
+
+        if (idea != null) {
+            String line = "核心想法：" + idea + "\n";
+            summaryBuilder.append(line);
+            lines.put("idea", line);
+        } else {
+            lines.put("idea", "");
+        }
+        if (genre != null) {
+            String line = "类型：" + genre + "\n";
+            summaryBuilder.append(line);
+            lines.put("genre", line);
+        } else {
+            lines.put("genre", "");
+        }
+        if (tone != null) {
+            String line = "基调：" + tone + "\n";
+            summaryBuilder.append(line);
+            lines.put("tone", line);
+        } else {
+            lines.put("tone", "");
+        }
+        if (!tags.isEmpty()) {
+            String line = "标签：" + String.join("，", tags) + "\n";
+            summaryBuilder.append(line);
+            lines.put("tags", line);
+        } else {
+            lines.put("tags", "");
+        }
+
+        if (summaryBuilder.length() == 0) {
+            summaryBuilder.append("核心想法：请根据用户提供的信息生成故事。\n");
+        }
+        summaryBuilder.append("\n");
+
+        Map<String, Object> context = new LinkedHashMap<>();
+        context.put("summary", summaryBuilder.toString());
+        context.put("lines", lines);
+
+        root.put("idea", idea == null ? "" : idea);
+        root.put("type", genre == null ? "" : genre);
+        root.put("genre", genre == null ? "" : genre);
+        root.put("tone", tone == null ? "" : tone);
+        root.put("tags", tags);
+        root.put("tag", tags);
+        root.put("context", context);
+        root.put("request", Map.of("raw", request));
+        return root;
+    }
+
+    private String safeTrim(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/service/AiService.java
+++ b/backend/src/main/java/com/example/ainovel/service/AiService.java
@@ -20,11 +20,19 @@ public interface AiService {
 
     ConceptionResponse generateConception(ConceptionRequest request, String apiKey);
 
+    default ConceptionResponse generateConception(Long userId, ConceptionRequest request, String apiKey, String baseUrl, String model) {
+        return generateConception(request, apiKey, baseUrl, model);
+    }
+
     default ConceptionResponse generateConception(ConceptionRequest request, String apiKey, String baseUrl, String model) {
         return generateConception(request, apiKey);
     }
 
     String refineText(RefineRequest request, String apiKey);
+
+    default String refineText(Long userId, RefineRequest request, String apiKey, String baseUrl, String model) {
+        return refineText(request, apiKey, baseUrl, model);
+    }
 
     default String refineText(RefineRequest request, String apiKey, String baseUrl, String model) {
         return refineText(request, apiKey);

--- a/backend/src/main/java/com/example/ainovel/service/ConceptionService.java
+++ b/backend/src/main/java/com/example/ainovel/service/ConceptionService.java
@@ -56,7 +56,7 @@ public class ConceptionService {
         String baseUrl = settingsService.getBaseUrlByUserId(user.getId());
         String model = settingsService.getModelNameByUserId(user.getId());
 
-        ConceptionResponse responseFromAi = openAiService.generateConception(request, apiKey, baseUrl, model);
+        ConceptionResponse responseFromAi = openAiService.generateConception(user.getId(), request, apiKey, baseUrl, model);
 
         StoryCard storyCard = responseFromAi.getStoryCard();
         if (storyCard == null) {
@@ -226,7 +226,7 @@ public class ConceptionService {
         String apiKey = getApiKeyForUser(user);
         String baseUrl = settingsService.getBaseUrlByUserId(user.getId());
         String model = settingsService.getModelNameByUserId(user.getId());
-        String refinedText = openAiService.refineText(request, apiKey, baseUrl, model);
+        String refinedText = openAiService.refineText(user.getId(), request, apiKey, baseUrl, model);
         return new RefineResponse(refinedText);
     }
 

--- a/backend/src/main/java/com/example/ainovel/service/OpenAiService.java
+++ b/backend/src/main/java/com/example/ainovel/service/OpenAiService.java
@@ -21,6 +21,8 @@ import org.springframework.web.client.RestTemplate;
 import com.example.ainovel.dto.ConceptionResponse;
 import com.example.ainovel.model.CharacterCard;
 import com.example.ainovel.model.StoryCard;
+import com.example.ainovel.prompt.PromptTemplateService;
+import com.example.ainovel.prompt.context.PromptContextFactory;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -60,8 +62,11 @@ public class OpenAiService extends AbstractAiService {
     @Value("${openai.model.default:gpt-4-turbo}")
     private String defaultModel;
 
-    public OpenAiService(RestTemplate restTemplate, ObjectMapper objectMapper) {
-        super(objectMapper);
+    public OpenAiService(RestTemplate restTemplate,
+                         ObjectMapper objectMapper,
+                         PromptTemplateService promptTemplateService,
+                         PromptContextFactory promptContextFactory) {
+        super(objectMapper, promptTemplateService, promptContextFactory);
         this.restTemplate = restTemplate;
     }
 

--- a/backend/src/main/resources/prompts/default-prompts.yaml
+++ b/backend/src/main/resources/prompts/default-prompts.yaml
@@ -1,0 +1,121 @@
+storyCreation: |
+  你是一个世界级的小说家。请根据以下用户输入生成一个详细的故事构思：
+  ${context.summary}
+  请严格按照以下JSON格式返回：
+  {
+    "storyCard": {
+      "title": "故事标题",
+      "synopsis": "(要求：详细、丰富的故事梗概，长度不少于400字)",
+      "worldview": "(要求：基于梗概生成详细的世界观设定)"
+    },
+    "characterCards": [
+      {
+        "name": "角色姓名",
+        "synopsis": "角色简介（年龄、性别、外貌、性格等）",
+        "details": "角色的详细背景故事和设定",
+        "relationships": "角色与其他主要角色的关系",
+        "avatarUrl": "（可选）角色的头像URL"
+      }
+    ]
+  }
+  characterCards要基于梗概生成3-5个主要角色描述。只返回JSON对象，不要包含任何额外的解释或markdown格式。
+outlineChapter: |
+  你是一位洞悉读者心理、擅长制造“爽点”与“泪点”的顶尖网络小说家。现在，请你以合作者的身份，为我的故事设计接下来的一章。我希望这一章不仅是情节的推进，更是情感的积累和爆发。
+
+  # 故事核心信息
+  - **故事简介:** ${story.synopsis}
+  - **核心主题与基调:** ${story.genre} / ${story.tone}
+  - **故事长期走向:** ${story.storyArc}
+
+  # 主要角色设定
+  ${characters.summary}
+
+  # 上下文回顾
+  - **上一章梗概:** ${chapter.previousSynopsis}
+
+  # 本章创作任务 (第 ${chapter.number} 章)
+  - **预设节数:** ${chapter.sectionsPerChapter}
+  - **预估每节字数:** ${chapter.wordsPerSection}
+
+  # 你的创作目标与自由度
+  1.  **情节设计:** 请构思一章充满“钩子”的情节。思考：这一章的结尾，最能让读者好奇地想读下一章的悬念是什么？中间是否可以安排一个小的“情绪爆点”或“情节反转”？
+  2.  **人物弧光:** 思考核心人物在本章的经历，他们的内心会产生怎样的变化？他们的信念是会更坚定，还是会受到挑战？
+  3.  **伏笔与回收:** 如果有机会，可以埋下一些与长线剧情相关的伏笔。如果前文有伏笔，思考本章是否是回收它的好时机。
+  4.  **创作建议 (重要):** 在满足核心要求的前提下，你完全可以提出更有创意的想法。例如，你认为某个临时人物的设定稍微调整一下会更有戏剧性，或者某个情节有更好的表现方式，请大胆地在你的设计中体现出来，并用 `[创作建议]` 标签标注。
+  5.  **拒绝平庸:** 请极力避免机械地推进剧情。每一节都应该有其独特的作用，或是塑造人物，或是铺垫情绪，或是揭示信息。
+  6.  **关键节点呈现:** 对于每节大纲，应当写一篇长简介，而是应该写出本节的多个关键故事节点（按照每节的预定长度来决定关键故事节点个数，可考虑平均每200-400字一个关键节点），每个关键故事节点只有两三句话。
+  7.  **语言风格:** 应当减少比喻、排比等修辞手法的使用，仅在认为确实有必要的情况下才少量使用；同时减少套路化的写作格式和剧情走向，允许在一定程度上自由发挥。
+
+  # 输出格式
+  请严格以JSON格式返回。根对象应包含 "title", "synopsis" 和一个 "scenes" 数组。
+  每个 scene 对象必须包含:
+  - "sceneNumber": (number) 序号。
+  - "synopsis": (string) 详细、生动、充满画面感的故事梗概，字数不少于200字。
+  - "presentCharacters": (string[]) 核心出场人物姓名列表。
+  - "sceneCharacters": (object[]) 一个数组，用结构化的“人物卡”描述每位核心人物在本节中的状态，字段必须包含:
+    - "characterName": (string) 角色姓名。
+    - "status": (string) 角色在本节的生理或环境状态。
+    - "thought": (string) 角色在本节的主要想法或心理活动。
+    - "action": (string) 角色在本节的关键行动。
+  - "temporaryCharacters": (object[]) 一个对象数组，用于描写本节新出现的或需要详细刻画的临时人物。如果不需要，则返回空数组[]。每个对象必须包含所有字段: "name", "summary", "details", "relationships", "status", "thought", "action"。
+manuscriptSection: |
+  你是一位资深的中文小说家，请使用简体中文进行创作。你的文风细腻而有张力，擅长通过细节与内心戏推动剧情。
+
+  【故事核心设定】
+  - 类型/基调: ${story.genre} / ${story.tone}
+  - 叙事视角: ${outline.pointOfView}
+  - 故事简介: ${story.synopsis}
+
+  【全部角色档案】
+  ${characters.allSummary}
+
+  【上一章大纲回顾】
+  ${previousChapter.summary}
+
+  【上一节正文（原文）】
+  ${previousSection.content}
+
+  【本章完整大纲】
+  ${currentChapter.summary}
+
+  【当前创作位置】
+  - 章节: 第 ${chapter.number}/${chapter.total} 章
+  - 小节: 第 ${scene.number}/${scene.totalInChapter} 节
+
+  【本节创作蓝图】
+  - 梗概: ${scene.synopsis}
+  - 核心出场人物: ${scene.presentCharacters}
+  - 核心人物状态卡:
+  ${scene.coreCharacterSummary}
+  - 临时出场人物:
+  ${scene.temporaryCharacterSummary}
+
+  【写作规则】
+  1. 钩子与悬念: 开篇30-80字设置强钩子；本节结尾制造悬念或情绪余韵。
+  2. 伏笔与回收: 合理埋设或回收伏笔，贴合剧情逻辑，避免突兀。
+  3. 人物弧光: 通过对话与行动自然呈现人物内心变化，拒绝直白说教。
+  4. 节奏与张力: 结合当前进度（第 ${chapter.number}/${chapter.total} 章，第 ${scene.number}/${scene.totalInChapter} 节）控制信息密度与冲突烈度。
+  5. 细节与画面: 强化感官细节、空间调度与象征性意象，避免模板化。
+  6. 忠于大纲，高于大纲: 不改变核心走向与设定，可进行合理艺术加工使剧情更佳。
+  7. 风格统一: 始终保持故事既定基调与叙事视角。
+  8. 输出要求: 直接输出本节“正文”，约 ${scene.expectedWords} 字；不要输出标题、注释或总结。
+  9. 语节制: 减少比喻、排比等修辞手法，仅在确有必要时少量使用。
+  10. 剧情新鲜: 避免套路化的表达和桥段，保持情节的惊喜度与原创性。
+  11. 自然质感: 让叙述与对话贴近人物的真实语感，避免机械化陈述。
+  12. 段落饱满: 每个自然段尽量写满多句内容，避免“一句话一个段落”的碎片化写法。
+
+  开始创作。
+refine:
+  withInstruction: |
+    你是一个专业的编辑。请根据我的修改意见，优化以下文本。${context.note}请只返回优化后的文本内容，不要包含任何解释性文字或Markdown格式。
+
+    原始文本:
+    "${text}"
+
+    我的意见:
+    "${instruction}"
+  withoutInstruction: |
+    你是一个专业的编辑。请优化以下文本，使其更生动、更具吸引力。${context.note}请只返回优化后的文本内容，不要包含任何解释性文字或Markdown格式。
+
+    原始文本:
+    "${text}"

--- a/backend/src/test/java/com/example/ainovel/prompt/TemplateEngineTest.java
+++ b/backend/src/test/java/com/example/ainovel/prompt/TemplateEngineTest.java
@@ -1,0 +1,71 @@
+package com.example.ainovel.prompt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class TemplateEngineTest {
+
+    private TemplateEngine templateEngine;
+
+    @BeforeEach
+    void setUp() {
+        templateEngine = new TemplateEngine(new ObjectMapper());
+    }
+
+    @Test
+    void rendersSimpleProperty() {
+        Map<String, Object> context = Map.of(
+                "user",
+                Map.of("name", "Alice")
+        );
+        String result = templateEngine.render("Hello ${user.name}!", context);
+        assertEquals("Hello Alice!", result);
+    }
+
+    @Test
+    void rendersListWithStarAndJoin() {
+        Map<String, Object> context = Map.of(
+                "items",
+                List.of(
+                        Map.of("value", "Alpha"),
+                        Map.of("value", "Beta"),
+                        Map.of("value", "Gamma")
+                )
+        );
+        String result = templateEngine.render("Values: ${items[*].value|join(\", \")}", context);
+        assertEquals("Values: Alpha, Beta, Gamma", result);
+    }
+
+    @Test
+    void appliesDefaultFunctionForMissingValue() {
+        String result = templateEngine.render("Value: ${missing|default(\"fallback\")}", Map.of());
+        assertEquals("Value: fallback", result);
+    }
+
+    @Test
+    void rendersEscapedExpression() {
+        String result = templateEngine.render("Show literal: $${value}", Map.of("value", "ignored"));
+        assertEquals("Show literal: ${value}", result);
+    }
+
+    @Test
+    void serializesJsonFunction() {
+        Map<String, Object> context = Map.of("payload", Map.of("key", "value"));
+        String result = templateEngine.render("${payload|json}", context);
+        assertEquals("{\"key\":\"value\"}", result);
+    }
+
+    @Test
+    void throwsForUnknownFunction() {
+        assertThrows(PromptTemplateException.class,
+                () -> templateEngine.render("${value|unknown()}", Map.of("value", "test")));
+    }
+}


### PR DESCRIPTION
## Summary
- add backend prompt template infrastructure including metadata DTOs, repository, defaults and REST controller
- refactor AI services and manuscript generation to render prompts through the new template engine and context builders
- add initial TemplateEngine unit tests covering interpolation, functions and error handling

## Testing
- `mvn test` *(fails: parent POM download blocked because external Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf79b77b308330851ac367377c99f6