### PR TITLE
Add prompt settings tab and help page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import Register from './components/Register';
 import Workbench from './components/Workbench';
 import HomePage from './components/HomePage';
 import ProtectedRoute from './components/ProtectedRoute';
+import Settings from './components/Settings';
+import PromptHelpPage from './components/PromptHelpPage';
 import { AuthProvider } from './contexts/AuthContext';
 
 function App() {
@@ -33,6 +35,22 @@ function App() {
           <Route path="/workbench/outline-design" element={<Navigate to="/workbench/outline-workspace" replace />} />
           <Route path="/workbench/outline-management" element={<Navigate to="/workbench/outline-workspace" replace />} />
           <Route path="/story-conception" element={<Navigate to="/workbench/story-conception" replace />} />
+          <Route
+            path="/settings"
+            element={
+              <ProtectedRoute>
+                <Settings />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings/prompt-guide"
+            element={
+              <ProtectedRoute>
+                <PromptHelpPage />
+              </ProtectedRoute>
+            }
+          />
         </Routes>
       </AuthProvider>
     </Router>

--- a/frontend/src/components/PromptHelpPage.tsx
+++ b/frontend/src/components/PromptHelpPage.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState, useMemo } from 'react';
+import { Card, Typography, Spin, Alert, Table, List, Space, Button } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { useNavigate } from 'react-router-dom';
+import { fetchPromptTemplateMetadata } from '../services/api';
+import type { PromptTemplateMetadata, PromptTypeMetadata, PromptFunctionMetadata, PromptVariableMetadata } from '../types';
+
+const { Title, Paragraph, Text } = Typography;
+
+type FunctionRow = PromptFunctionMetadata & { key: string };
+type VariableRow = PromptVariableMetadata & { key: string };
+
+type TableColumns<T> = ColumnsType<T>;
+
+const PromptHelpPage = () => {
+    const navigate = useNavigate();
+    const [metadata, setMetadata] = useState<PromptTemplateMetadata | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const loadMetadata = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const data = await fetchPromptTemplateMetadata();
+                setMetadata(data);
+            } catch (err) {
+                console.error('Failed to load prompt template metadata:', err);
+                const errorMessage = err instanceof Error ? err.message : '未知错误';
+                setError(`获取提示词帮助数据失败：${errorMessage}`);
+            } finally {
+                setLoading(false);
+            }
+        };
+        loadMetadata();
+    }, []);
+
+    const functionColumns: TableColumns<FunctionRow> = useMemo(() => [
+        { title: '函数', dataIndex: 'name', key: 'name', width: 220 },
+        { title: '作用', dataIndex: 'description', key: 'description' },
+        {
+            title: '使用示例',
+            dataIndex: 'usage',
+            key: 'usage',
+            render: (value: string) => <Text code>{value}</Text>,
+        },
+    ], []);
+
+    const variableColumns: TableColumns<VariableRow> = useMemo(() => [
+        { title: '变量名', dataIndex: 'name', key: 'name', width: 220 },
+        { title: '类型', dataIndex: 'valueType', key: 'valueType', width: 120 },
+        { title: '说明', dataIndex: 'description', key: 'description' },
+    ], []);
+
+    const buildVariableRows = (template: PromptTypeMetadata): VariableRow[] => {
+        return template.variables.map((variable, index) => ({
+            key: `${template.type}-${index}`,
+            ...variable,
+        }));
+    };
+
+    const functionRows: FunctionRow[] = metadata
+        ? metadata.functions.map((func, index) => ({ key: `${func.name}-${index}`, ...func }))
+        : [];
+
+    return (
+        <div style={{ padding: '24px', background: '#f0f2f5', minHeight: '100vh' }}>
+            <Card style={{ maxWidth: 1100, margin: '0 auto' }}>
+                <Space direction="vertical" size={24} style={{ width: '100%' }}>
+                    <Space align="center" style={{ justifyContent: 'space-between', width: '100%', flexWrap: 'wrap', gap: 12 }}>
+                        <Title level={2} style={{ margin: 0 }}>提示词编写帮助</Title>
+                        <Button onClick={() => navigate('/settings')} type="primary">
+                            返回设置
+                        </Button>
+                    </Space>
+                    <Paragraph>
+                        模板支持使用 <Text code>{'${变量}'}</Text> 语法插入上下文数据，并可通过管道函数调整输出格式。本页整理了全部可用的变量、函数与常见示例，帮助你更高效地编写提示词。
+                    </Paragraph>
+                    {error && <Alert type="error" showIcon message={error} />}
+                    <Spin spinning={loading}>
+                        <Space direction="vertical" size={16} style={{ width: '100%' }}>
+                            {metadata && (
+                                <>
+                                    <Card type="inner" title="插值语法速览">
+                                        <List
+                                            dataSource={metadata.syntaxTips}
+                                            renderItem={(item, index) => (
+                                                <List.Item key={`${index}-${item}`}>{item}</List.Item>
+                                            )}
+                                            bordered
+                                            split
+                                        />
+                                    </Card>
+                                    <Card type="inner" title="支持的函数">
+                                        <Table
+                                            columns={functionColumns}
+                                            dataSource={functionRows}
+                                            pagination={false}
+                                            size="middle"
+                                        />
+                                    </Card>
+                                    {metadata.templates.map(template => (
+                                        <Card
+                                            type="inner"
+                                            key={template.type}
+                                            title={`${template.label}（${template.type}）可用变量`}
+                                        >
+                                            <Table
+                                                columns={variableColumns}
+                                                dataSource={buildVariableRows(template)}
+                                                pagination={false}
+                                                size="middle"
+                                            />
+                                        </Card>
+                                    ))}
+                                    {metadata.examples.length > 0 && (
+                                        <Card type="inner" title="常用示例">
+                                            <List
+                                                dataSource={metadata.examples}
+                                                renderItem={(example, index) => (
+                                                    <List.Item key={`${index}-${example}`}>
+                                                        <Text code>{example}</Text>
+                                                    </List.Item>
+                                                )}
+                                                bordered
+                                                split
+                                            />
+                                        </Card>
+                                    )}
+                                </>
+                            )}
+                        </Space>
+                    </Spin>
+                    <Paragraph type="secondary">
+                        提示：想快速恢复系统模板，可以在设置页点击“恢复默认”。修改后的模板仅对当前账号生效。
+                    </Paragraph>
+                </Space>
+            </Card>
+        </div>
+    );
+};
+
+export default PromptHelpPage;

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1,7 +1,12 @@
-import { useState, useEffect } from 'react';
-import { Form, Input, Button, Card, Typography, message, Spin } from 'antd';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { Form, Input, Button, Card, Typography, message, Spin, Tabs, Space, Tag, Alert } from 'antd';
+import type { TabsProps } from 'antd';
+import { Link } from 'react-router-dom';
+import { fetchPromptTemplates, updatePromptTemplates, resetPromptTemplates } from '../services/api';
+import type { PromptTemplatesResponse, PromptTemplatesUpdatePayload } from '../types';
 
-const { Title } = Typography;
+const { Title, Paragraph, Text } = Typography;
+const { TextArea } = Input;
 
 interface SettingsValues {
     baseUrl?: string;
@@ -9,25 +14,82 @@ interface SettingsValues {
     apiKey?: string;
 }
 
+type PromptFieldKey = 'storyCreation' | 'outlineChapter' | 'manuscriptSection' | 'refineWithInstruction' | 'refineWithoutInstruction';
+type PromptFormValues = Record<PromptFieldKey, string>;
+
+const promptFieldOrder: PromptFieldKey[] = [
+    'storyCreation',
+    'outlineChapter',
+    'manuscriptSection',
+    'refineWithInstruction',
+    'refineWithoutInstruction',
+];
+
+const promptResetKeyMap: Record<PromptFieldKey, string> = {
+    storyCreation: 'storyCreation',
+    outlineChapter: 'outlineChapter',
+    manuscriptSection: 'manuscriptSection',
+    refineWithInstruction: 'refine.withInstruction',
+    refineWithoutInstruction: 'refine.withoutInstruction',
+};
+
+const promptFieldConfigs: Record<PromptFieldKey, { label: string; description: string }> = {
+    storyCreation: {
+        label: '故事构思提示词',
+        description: '用于根据用户想法生成故事卡片和主角设定。',
+    },
+    outlineChapter: {
+        label: '大纲章节提示词',
+        description: '用于编写章节级大纲与场景结构。',
+    },
+    manuscriptSection: {
+        label: '正文创作提示词',
+        description: '用于生成具体小节的小说正文。',
+    },
+    refineWithInstruction: {
+        label: '文本润色（带指令）',
+        description: '当你附带修改意见时使用此模板进行润色。',
+    },
+    refineWithoutInstruction: {
+        label: '文本润色（无指令）',
+        description: '仅需润色文本、无额外指令时使用。',
+    },
+};
+
 const Settings = () => {
-    const [form] = Form.useForm();
+    const [form] = Form.useForm<SettingsValues>();
+    const [activeTab, setActiveTab] = useState<'model' | 'prompts'>('model');
+
     const [isLoading, setIsLoading] = useState(true);
     const [isSaving, setIsSaving] = useState(false);
     const [isTesting, setIsTesting] = useState(false);
     const [apiKeyEditable, setApiKeyEditable] = useState(false);
     const [apiKeyIsSet, setApiKeyIsSet] = useState(false);
 
+    const [promptValues, setPromptValues] = useState<PromptFormValues>({
+        storyCreation: '',
+        outlineChapter: '',
+        manuscriptSection: '',
+        refineWithInstruction: '',
+        refineWithoutInstruction: '',
+    });
+    const [promptTemplatesData, setPromptTemplatesData] = useState<PromptTemplatesResponse | null>(null);
+    const [isPromptLoading, setIsPromptLoading] = useState(false);
+    const [isPromptSaving, setIsPromptSaving] = useState(false);
+    const [promptError, setPromptError] = useState<string | null>(null);
+    const [resettingKey, setResettingKey] = useState<PromptFieldKey | null>(null);
+
     useEffect(() => {
         const fetchSettings = async () => {
             setIsLoading(true);
             try {
                 const response = await fetch('/api/v1/settings', {
-                    headers: { 'Authorization': `Bearer ${localStorage.getItem('token')}` }
+                    headers: { 'Authorization': `Bearer ${localStorage.getItem('token')}` },
                 });
                 if (response.ok) {
                     const text = await response.text();
                     if (text) {
-                        const data = JSON.parse(text);
+                        const data = JSON.parse(text) as SettingsValues & { apiKeyIsSet?: boolean };
                         setApiKeyIsSet(!!data.apiKeyIsSet);
                         setApiKeyEditable(!data.apiKeyIsSet);
                         form.setFieldsValue({
@@ -64,6 +126,34 @@ const Settings = () => {
         fetchSettings();
     }, [form]);
 
+    const loadPromptTemplates = useCallback(async () => {
+        setIsPromptLoading(true);
+        setPromptError(null);
+        try {
+            const data = await fetchPromptTemplates();
+            setPromptTemplatesData(data);
+            const newValues: PromptFormValues = {
+                storyCreation: data.storyCreation.content,
+                outlineChapter: data.outlineChapter.content,
+                manuscriptSection: data.manuscriptSection.content,
+                refineWithInstruction: data.refine.withInstruction.content,
+                refineWithoutInstruction: data.refine.withoutInstruction.content,
+            };
+            setPromptValues(newValues);
+        } catch (error: unknown) {
+            console.error('Failed to load prompt templates:', error);
+            const errorMessage = error instanceof Error ? error.message : '未知错误';
+            setPromptError(`加载提示词模板失败：${errorMessage}`);
+            message.error(`加载提示词模板失败：${errorMessage}`);
+        } finally {
+            setIsPromptLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        loadPromptTemplates();
+    }, [loadPromptTemplates]);
+
     const onFinish = async (values: SettingsValues) => {
         setIsSaving(true);
         try {
@@ -71,7 +161,6 @@ const Settings = () => {
                 baseUrl: values.baseUrl ?? '',
                 modelName: values.modelName ?? '',
             };
-            // 仅当用户主动修改过 apiKey 且不是占位符时，才提交给后端
             if (apiKeyEditable && values.apiKey && values.apiKey.trim() !== '' && values.apiKey !== '********') {
                 payload.apiKey = values.apiKey.trim();
             }
@@ -80,13 +169,12 @@ const Settings = () => {
                 method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${localStorage.getItem('token')}`
+                    'Authorization': `Bearer ${localStorage.getItem('token')}`,
                 },
                 body: JSON.stringify(payload),
             });
             if (response.ok) {
                 message.success('设置已成功保存！');
-                // 如果这次提交包含 apiKey，则视为已设置并改为占位显示、锁定输入
                 if ('apiKey' in payload) {
                     setApiKeyIsSet(true);
                     setApiKeyEditable(false);
@@ -126,7 +214,7 @@ const Settings = () => {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${localStorage.getItem('token')}`
+                    'Authorization': `Bearer ${localStorage.getItem('token')}`,
                 },
                 body: JSON.stringify(testPayload),
             });
@@ -149,62 +237,245 @@ const Settings = () => {
         }
     };
 
+    const handlePromptChange = (key: PromptFieldKey, value: string) => {
+        setPromptValues(prev => ({
+            ...prev,
+            [key]: value,
+        } as PromptFormValues));
+    };
+
+    const getSavedContent = useCallback((key: PromptFieldKey): string => {
+        if (!promptTemplatesData) {
+            return '';
+        }
+        switch (key) {
+            case 'storyCreation':
+                return promptTemplatesData.storyCreation.content;
+            case 'outlineChapter':
+                return promptTemplatesData.outlineChapter.content;
+            case 'manuscriptSection':
+                return promptTemplatesData.manuscriptSection.content;
+            case 'refineWithInstruction':
+                return promptTemplatesData.refine.withInstruction.content;
+            case 'refineWithoutInstruction':
+                return promptTemplatesData.refine.withoutInstruction.content;
+            default:
+                return '';
+        }
+    }, [promptTemplatesData]);
+
+    const getSavedIsDefault = useCallback((key: PromptFieldKey): boolean => {
+        if (!promptTemplatesData) {
+            return true;
+        }
+        switch (key) {
+            case 'storyCreation':
+                return promptTemplatesData.storyCreation.default;
+            case 'outlineChapter':
+                return promptTemplatesData.outlineChapter.default;
+            case 'manuscriptSection':
+                return promptTemplatesData.manuscriptSection.default;
+            case 'refineWithInstruction':
+                return promptTemplatesData.refine.withInstruction.default;
+            case 'refineWithoutInstruction':
+                return promptTemplatesData.refine.withoutInstruction.default;
+            default:
+                return true;
+        }
+    }, [promptTemplatesData]);
+
+    const isPromptDirty = useMemo(() => {
+        if (!promptTemplatesData) {
+            return false;
+        }
+        return promptFieldOrder.some(key => promptValues[key] !== getSavedContent(key));
+    }, [promptTemplatesData, promptValues, getSavedContent]);
+
+    const handleSavePrompts = async () => {
+        const payload: PromptTemplatesUpdatePayload = {
+            storyCreation: promptValues.storyCreation,
+            outlineChapter: promptValues.outlineChapter,
+            manuscriptSection: promptValues.manuscriptSection,
+            refine: {
+                withInstruction: promptValues.refineWithInstruction,
+                withoutInstruction: promptValues.refineWithoutInstruction,
+            },
+        };
+
+        setIsPromptSaving(true);
+        setPromptError(null);
+        try {
+            await updatePromptTemplates(payload);
+            message.success('提示词模板已保存。');
+            await loadPromptTemplates();
+        } catch (error: unknown) {
+            console.error('Failed to save prompt templates:', error);
+            const errorMessage = error instanceof Error ? error.message : '未知错误';
+            setPromptError(`保存提示词失败：${errorMessage}`);
+            message.error(`保存提示词失败：${errorMessage}`);
+        } finally {
+            setIsPromptSaving(false);
+        }
+    };
+
+    const handleResetPrompt = async (key: PromptFieldKey) => {
+        setResettingKey(key);
+        setPromptError(null);
+        try {
+            await resetPromptTemplates([promptResetKeyMap[key]]);
+            message.success('已恢复系统默认模板。');
+            await loadPromptTemplates();
+        } catch (error: unknown) {
+            console.error('Failed to reset prompt template:', error);
+            const errorMessage = error instanceof Error ? error.message : '未知错误';
+            setPromptError(`恢复默认模板失败：${errorMessage}`);
+            message.error(`恢复默认模板失败：${errorMessage}`);
+        } finally {
+            setResettingKey(null);
+        }
+    };
+
+    const getFieldStatus = (key: PromptFieldKey): { label: string; color: string } => {
+        if (!promptTemplatesData) {
+            return { label: '加载中', color: 'default' };
+        }
+        if (promptValues[key] !== getSavedContent(key)) {
+            return { label: '已修改（未保存）', color: 'processing' };
+        }
+        if (getSavedIsDefault(key)) {
+            return { label: '系统默认模板', color: 'default' };
+        }
+        return { label: '自定义模板', color: 'success' };
+    };
+
+    const renderModelSettings = () => (
+        <Spin spinning={isLoading}>
+            <Space direction="vertical" size={16} style={{ width: '100%' }}>
+                <Paragraph type="secondary">
+                    配置访问大语言模型所需的基础信息。密钥仅用于调用，不会以明文存储。
+                </Paragraph>
+                <Form form={form} layout="vertical" onFinish={onFinish}>
+                    <Form.Item name="baseUrl" label="Base URL" tooltip="可选：自定义 OpenAI 兼容服务的基础地址">
+                        <Input placeholder="例如：https://api.openai.com/v1 或自建网关地址" />
+                    </Form.Item>
+                    <Form.Item name="modelName" label="模型名称" tooltip="例如 gpt-4o-mini, gpt-4-turbo">
+                        <Input placeholder="输入模型名称" />
+                    </Form.Item>
+                    <Form.Item
+                        name="apiKey"
+                        label="API 密钥"
+                        tooltip="后端不回显密钥原文。若显示“********”，表示已设置。点击“修改”可重新输入。"
+                    >
+                        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                            <Input.Password
+                                placeholder={apiKeyIsSet ? '********' : '输入您的 API 密钥'}
+                                disabled={!apiKeyEditable}
+                            />
+                            {apiKeyIsSet && (
+                                <Button
+                                    onClick={() => {
+                                        if (apiKeyEditable) {
+                                            form.setFieldsValue({ apiKey: '********' });
+                                            setApiKeyEditable(false);
+                                        } else {
+                                            form.setFieldsValue({ apiKey: '' });
+                                            setApiKeyEditable(true);
+                                        }
+                                    }}
+                                >
+                                    {apiKeyEditable ? '取消' : '修改'}
+                                </Button>
+                            )}
+                        </div>
+                        <div style={{ marginTop: 8, color: apiKeyIsSet ? '#52c41a' : '#faad14' }}>
+                            {apiKeyIsSet ? '密钥状态：已设置' : '密钥状态：未设置'}
+                        </div>
+                    </Form.Item>
+                    <Form.Item>
+                        <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+                            <Button type="primary" htmlType="submit" loading={isSaving} style={{ flex: 1, minWidth: 120 }}>
+                                保存设置
+                            </Button>
+                            <Button onClick={handleTestConnection} loading={isTesting} style={{ flex: 1, minWidth: 120 }}>
+                                测试连接
+                            </Button>
+                        </div>
+                    </Form.Item>
+                </Form>
+            </Space>
+        </Spin>
+    );
+
+    const renderPromptSettings = () => (
+        <Spin spinning={isPromptLoading}>
+            <Space direction="vertical" size={16} style={{ width: '100%' }}>
+                <Paragraph>
+                    你可以为不同场景编写独立的提示词模板，使用 <Text code>{'${变量}'}</Text> 形式插入上下文数据。查看{' '}
+                    <Link to="/settings/prompt-guide">提示词编写帮助</Link>，了解所有可用变量与函数。
+                </Paragraph>
+                {promptError && <Alert type="error" showIcon message={promptError} />}
+                {isPromptDirty && !promptError && (
+                    <Alert type="warning" showIcon message="提示词内容已修改但尚未保存。" />
+                )}
+                {promptFieldOrder.map(key => {
+                    const config = promptFieldConfigs[key];
+                    const status = getFieldStatus(key);
+                    return (
+                        <Card key={key} size="small">
+                            <Space direction="vertical" size={12} style={{ width: '100%' }}>
+                                <Space style={{ justifyContent: 'space-between', alignItems: 'center', width: '100%', flexWrap: 'wrap', gap: 12 }}>
+                                    <div>
+                                        <Title level={5} style={{ marginBottom: 4 }}>{config.label}</Title>
+                                        <Text type="secondary">{config.description}</Text>
+                                    </div>
+                                    <Tag color={status.color}>{status.label}</Tag>
+                                </Space>
+                                <TextArea
+                                    value={promptValues[key]}
+                                    onChange={event => handlePromptChange(key, event.target.value)}
+                                    autoSize={{ minRows: 8, maxRows: 40 }}
+                                    showCount
+                                    spellCheck={false}
+                                />
+                                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                                    <Button
+                                        onClick={() => handleResetPrompt(key)}
+                                        loading={resettingKey === key}
+                                        disabled={isPromptSaving}
+                                    >
+                                        恢复默认
+                                    </Button>
+                                </div>
+                            </Space>
+                        </Card>
+                    );
+                })}
+                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <Button
+                        type="primary"
+                        onClick={handleSavePrompts}
+                        loading={isPromptSaving}
+                        disabled={!isPromptDirty}
+                    >
+                        保存提示词
+                    </Button>
+                </div>
+            </Space>
+        </Spin>
+    );
+
+    const items: TabsProps['items'] = [
+        { key: 'model', label: '模型设置', children: renderModelSettings() },
+        { key: 'prompts', label: '提示词配置', children: renderPromptSettings() },
+    ];
+
     return (
         <div style={{ padding: '24px', background: '#f0f2f5', minHeight: '100vh' }}>
-            <Card style={{ maxWidth: 600, margin: 'auto' }}>
-                <Title level={3}>AI 模型设置</Title>
-                <Spin spinning={isLoading}>
-                    <Form form={form} layout="vertical" onFinish={onFinish}>
-                        <Form.Item name="baseUrl" label="Base URL" tooltip="可选：自定义 OpenAI 兼容服务的基础地址">
-                            <Input placeholder="例如：https://api.openai.com/v1 或自建网关地址" />
-                        </Form.Item>
-                        <Form.Item name="modelName" label="模型名称" tooltip="例如 gpt-4o-mini, gpt-4-turbo">
-                            <Input placeholder="输入模型名称" />
-                        </Form.Item>
-                        <Form.Item
-                            name="apiKey"
-                            label="API 密钥"
-                            tooltip="后端不回显密钥原文。若显示“********”，表示已设置。点击“修改”可重新输入。"
-                        >
-                            <div style={{ display: 'flex', gap: 8 }}>
-                                <Input.Password
-                                    placeholder={apiKeyIsSet ? '********' : '输入您的 API 密钥'}
-                                    disabled={!apiKeyEditable}
-                                />
-                                {apiKeyIsSet && (
-                                    <Button
-                                        onClick={() => {
-                                            if (apiKeyEditable) {
-                                                // 取消编辑，恢复占位
-                                                form.setFieldsValue({ apiKey: '********' });
-                                                setApiKeyEditable(false);
-                                            } else {
-                                                // 开启编辑，清空输入
-                                                form.setFieldsValue({ apiKey: '' });
-                                                setApiKeyEditable(true);
-                                            }
-                                        }}
-                                    >
-                                        {apiKeyEditable ? '取消' : '修改'}
-                                    </Button>
-                                )}
-                            </div>
-                            <div style={{ marginTop: 8, color: apiKeyIsSet ? '#52c41a' : '#faad14' }}>
-                                {apiKeyIsSet ? '密钥状态：已设置' : '密钥状态：未设置'}
-                            </div>
-                        </Form.Item>
-                        <Form.Item>
-                            <div style={{ display: 'flex', gap: '16px' }}>
-                                <Button type="primary" htmlType="submit" loading={isSaving} style={{ flex: 1 }}>
-                                    保存设置
-                                </Button>
-                                <Button onClick={handleTestConnection} loading={isTesting} style={{ flex: 1 }}>
-                                    测试连接
-                                </Button>
-                            </div>
-                        </Form.Item>
-                    </Form>
-                </Spin>
+            <Card style={{ maxWidth: 1000, margin: '0 auto' }}>
+                <Space direction="vertical" size={24} style={{ width: '100%' }}>
+                    <Title level={3} style={{ margin: 0 }}>用户设置</Title>
+                    <Tabs items={items} activeKey={activeTab} onChange={key => setActiveTab(key as 'model' | 'prompts')} />
+                </Space>
             </Card>
         </div>
     );

--- a/frontend/src/components/Workbench.tsx
+++ b/frontend/src/components/Workbench.tsx
@@ -31,7 +31,6 @@ import EditCharacterCardModal from './modals/EditCharacterCardModal';
 import EditOutlineModal from './modals/EditOutlineModal';
 import RefineModal from './modals/RefineModal';
 import WorkbenchHeader from './WorkbenchHeader';
-import UserSettingsModal from './modals/UserSettingsModal';
 import { useAuth } from '../contexts/AuthContext';
 
 const SparklesSvg = () => (
@@ -50,7 +49,6 @@ const Workbench = () => {
     const { tab } = useParams<{ tab: string }>();
     const navigate = useNavigate();
     const { user, logout } = useAuth();
-    const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
     const normalizeTab = (t?: string) => {
         if (!t) return "story-conception";
@@ -299,7 +297,7 @@ const Workbench = () => {
         <Layout style={{ minHeight: '100vh' }}>
             <WorkbenchHeader
                 username={user?.username}
-                onOpenSettings={() => setIsSettingsOpen(true)}
+                onOpenSettings={() => navigate('/settings')}
                 onLogout={() => { logout(); navigate('/'); }}
             />
             <Content style={{ padding: '24px', margin: 0, background: '#f0f2f5' }}>
@@ -442,10 +440,6 @@ const Workbench = () => {
                 originalText={originalText}
                 contextType={context?.fieldName || ''}
                 onRefined={handleAcceptRefinement}
-            />
-            <UserSettingsModal
-                open={isSettingsOpen}
-                onClose={() => setIsSettingsOpen(false)}
             />
         </Layout>
     );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,4 @@
-import type { StoryCard, CharacterCard, Outline, ConceptionFormValues, Chapter, Manuscript, ManuscriptSection, CharacterChangeLog, CharacterDialogueRequestPayload, CharacterDialogueResponsePayload } from '../types';
+import type { StoryCard, CharacterCard, Outline, ConceptionFormValues, Chapter, Manuscript, ManuscriptSection, CharacterChangeLog, CharacterDialogueRequestPayload, CharacterDialogueResponsePayload, PromptTemplatesResponse, PromptTemplatesUpdatePayload, PromptTemplateMetadata } from '../types';
 
 /**
  * Creates authorization headers for API requests.
@@ -33,7 +33,7 @@ const handleResponse = async <T>(response: Response): Promise<T> => {
                 message = errorData.message || errorData.error;
             }
             console.error('API request failed:', response.status, errorData);
-        } catch (_) {
+        } catch {
             try {
                 const text = await response.text();
                 if (text) message = text;
@@ -343,6 +343,32 @@ export const generateDialogue = (payload: CharacterDialogueRequestPayload): Prom
         headers: getAuthHeaders(),
         body: JSON.stringify(payload),
     }).then(res => handleResponse<CharacterDialogueResponsePayload>(res));
+};
+
+export const fetchPromptTemplates = (): Promise<PromptTemplatesResponse> => {
+    return fetch('/api/v1/prompt-templates', { headers: getAuthHeaders() })
+        .then(res => handleResponse<PromptTemplatesResponse>(res));
+};
+
+export const updatePromptTemplates = (payload: PromptTemplatesUpdatePayload): Promise<void> => {
+    return fetch('/api/v1/prompt-templates', {
+        method: 'PUT',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(payload),
+    }).then(res => handleResponse<void>(res));
+};
+
+export const resetPromptTemplates = (keys: string[]): Promise<void> => {
+    return fetch('/api/v1/prompt-templates/reset', {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify({ keys }),
+    }).then(res => handleResponse<void>(res));
+};
+
+export const fetchPromptTemplateMetadata = (): Promise<PromptTemplateMetadata> => {
+    return fetch('/api/v1/prompt-templates/metadata', { headers: getAuthHeaders() })
+        .then(res => handleResponse<PromptTemplateMetadata>(res));
 };
 
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -152,3 +152,55 @@ export interface CharacterDialogueResponsePayload {
 }
 
 export type RefineHandler = (text: string, context: RefineContext) => void;
+
+export interface PromptTemplateItem {
+    content: string;
+    default: boolean;
+}
+
+export interface RefinePromptTemplateGroup {
+    withInstruction: PromptTemplateItem;
+    withoutInstruction: PromptTemplateItem;
+}
+
+export interface PromptTemplatesResponse {
+    storyCreation: PromptTemplateItem;
+    outlineChapter: PromptTemplateItem;
+    manuscriptSection: PromptTemplateItem;
+    refine: RefinePromptTemplateGroup;
+}
+
+export interface PromptTemplatesUpdatePayload {
+    storyCreation?: string;
+    outlineChapter?: string;
+    manuscriptSection?: string;
+    refine?: {
+        withInstruction?: string;
+        withoutInstruction?: string;
+    };
+}
+
+export interface PromptVariableMetadata {
+    name: string;
+    valueType: string;
+    description: string;
+}
+
+export interface PromptTypeMetadata {
+    type: string;
+    label: string;
+    variables: PromptVariableMetadata[];
+}
+
+export interface PromptFunctionMetadata {
+    name: string;
+    description: string;
+    usage: string;
+}
+
+export interface PromptTemplateMetadata {
+    templates: PromptTypeMetadata[];
+    functions: PromptFunctionMetadata[];
+    syntaxTips: string[];
+    examples: string[];
+}


### PR DESCRIPTION
## Summary
- add a dedicated prompt configuration tab in the settings view with save/reset actions, default status indicators, and a help link
- introduce a prompt help page fed by backend metadata describing syntax, variables, and functions
- expose prompt template API helpers and types while wiring navigation, Workbench routing, and auth context updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfa8a9f7648330be4807512f59b4fc