### PR TITLE
Add return button and normalize prompt template newlines

### DIFF
--- a/backend/src/main/java/com/example/ainovel/prompt/PromptTemplateService.java
+++ b/backend/src/main/java/com/example/ainovel/prompt/PromptTemplateService.java
@@ -112,22 +112,22 @@ public class PromptTemplateService {
             return;
         }
         if (request.getStoryCreation() != null) {
-            settings.setStoryCreation(request.getStoryCreation());
+            settings.setStoryCreation(normalizeLineEndings(request.getStoryCreation()));
         }
         if (request.getOutlineChapter() != null) {
-            settings.setOutlineChapter(request.getOutlineChapter());
+            settings.setOutlineChapter(normalizeLineEndings(request.getOutlineChapter()));
         }
         if (request.getManuscriptSection() != null) {
-            settings.setManuscriptSection(request.getManuscriptSection());
+            settings.setManuscriptSection(normalizeLineEndings(request.getManuscriptSection()));
         }
         RefinePromptTemplatesUpdateRequest refine = request.getRefine();
         if (refine != null) {
             RefinePromptSettings refineSettings = settings.ensureRefine();
             if (refine.getWithInstruction() != null) {
-                refineSettings.setWithInstruction(refine.getWithInstruction());
+                refineSettings.setWithInstruction(normalizeLineEndings(refine.getWithInstruction()));
             }
             if (refine.getWithoutInstruction() != null) {
-                refineSettings.setWithoutInstruction(refine.getWithoutInstruction());
+                refineSettings.setWithoutInstruction(normalizeLineEndings(refine.getWithoutInstruction()));
             }
         }
     }
@@ -206,6 +206,13 @@ public class PromptTemplateService {
 
     private boolean isBlank(String value) {
         return value == null || value.trim().isEmpty();
+    }
+
+    private String normalizeLineEndings(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replace("\r\n", "\n").replace('\r', '\n');
     }
 
     private String getDefaultTemplate(PromptType type) {

--- a/backend/src/test/java/com/example/ainovel/prompt/PromptTemplateServiceTest.java
+++ b/backend/src/test/java/com/example/ainovel/prompt/PromptTemplateServiceTest.java
@@ -1,0 +1,73 @@
+package com.example.ainovel.prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.ainovel.dto.prompt.PromptTemplatesUpdateRequest;
+import com.example.ainovel.dto.prompt.RefinePromptTemplatesUpdateRequest;
+import com.example.ainovel.model.prompt.PromptSettings;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class PromptTemplateServiceTest {
+
+    @Mock
+    private PromptTemplateRepository promptTemplateRepository;
+
+    private PromptTemplateService promptTemplateService;
+
+    @BeforeEach
+    void setUp() {
+        PromptDefaults defaults = new PromptDefaults();
+        defaults.setStoryCreation("default story");
+        defaults.setOutlineChapter("default outline");
+        defaults.setManuscriptSection("default manuscript");
+        RefinePromptDefaults refineDefaults = new RefinePromptDefaults();
+        refineDefaults.setWithInstruction("default with");
+        refineDefaults.setWithoutInstruction("default without");
+        defaults.setRefine(refineDefaults);
+
+        promptTemplateService = new PromptTemplateService(
+                promptTemplateRepository,
+                defaults,
+                new TemplateEngine(new ObjectMapper()),
+                new PromptTemplateMetadataProvider());
+    }
+
+    @Test
+    void saveTemplatesNormalizesLineEndings() {
+        when(promptTemplateRepository.findByUserId(1L)).thenReturn(Optional.empty());
+
+        PromptTemplatesUpdateRequest request = new PromptTemplatesUpdateRequest()
+                .setStoryCreation("line1\r\nline2\rline3\nline4")
+                .setOutlineChapter("outline\r\nsecond")
+                .setManuscriptSection("section\ronly")
+                .setRefine(new RefinePromptTemplatesUpdateRequest()
+                        .setWithInstruction("with\r\nvalue")
+                        .setWithoutInstruction("without\rvalue"));
+
+        promptTemplateService.saveTemplates(1L, request);
+
+        ArgumentCaptor<PromptSettings> settingsCaptor = ArgumentCaptor.forClass(PromptSettings.class);
+        verify(promptTemplateRepository).save(eq(1L), settingsCaptor.capture());
+
+        PromptSettings savedSettings = settingsCaptor.getValue();
+        assertThat(savedSettings.getStoryCreation()).isEqualTo("line1\nline2\nline3\nline4");
+        assertThat(savedSettings.getOutlineChapter()).isEqualTo("outline\nsecond");
+        assertThat(savedSettings.getManuscriptSection()).isEqualTo("section\nonly");
+        assertThat(savedSettings.getRefine()).isNotNull();
+        assertThat(savedSettings.getRefine().getWithInstruction()).isEqualTo("with\nvalue");
+        assertThat(savedSettings.getRefine().getWithoutInstruction()).isEqualTo("without\nvalue");
+    }
+}

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { Form, Input, Button, Card, Typography, message, Spin, Tabs, Space, Tag, Alert } from 'antd';
 import type { TabsProps } from 'antd';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { fetchPromptTemplates, updatePromptTemplates, resetPromptTemplates } from '../services/api';
 import type { PromptTemplatesResponse, PromptTemplatesUpdatePayload } from '../types';
 
@@ -59,6 +59,7 @@ const promptFieldConfigs: Record<PromptFieldKey, { label: string; description: s
 const Settings = () => {
     const [form] = Form.useForm<SettingsValues>();
     const [activeTab, setActiveTab] = useState<'model' | 'prompts'>('model');
+    const navigate = useNavigate();
 
     const [isLoading, setIsLoading] = useState(true);
     const [isSaving, setIsSaving] = useState(false);
@@ -473,7 +474,18 @@ const Settings = () => {
         <div style={{ padding: '24px', background: '#f0f2f5', minHeight: '100vh' }}>
             <Card style={{ maxWidth: 1000, margin: '0 auto' }}>
                 <Space direction="vertical" size={24} style={{ width: '100%' }}>
-                    <Title level={3} style={{ margin: 0 }}>用户设置</Title>
+                    <div
+                        style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            flexWrap: 'wrap',
+                            gap: 12,
+                        }}
+                    >
+                        <Title level={3} style={{ margin: 0 }}>用户设置</Title>
+                        <Button onClick={() => navigate(-1)}>返回</Button>
+                    </div>
                     <Tabs items={items} activeKey={activeTab} onChange={key => setActiveTab(key as 'model' | 'prompts')} />
                 </Space>
             </Card>


### PR DESCRIPTION
## Summary
- add a return button to the user settings page so users can return to the previous view
- normalize line endings when saving prompt templates to preserve configured newlines
- cover the newline normalization with a dedicated unit test

## Testing
- npm run build
- ./mvnw test *(fails: cannot resolve parent POM because Maven Central was unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe6f092408330a145377796c1913d