### PR TITLE
feat: implement world building backend foundations

### DIFF
--- a/backend/src/database.sql
+++ b/backend/src/database.sql
@@ -199,6 +199,56 @@ ADD COLUMN `mood_in_scene` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci
 ADD COLUMN `actions_in_scene` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL DEFAULT NULL COMMENT '在本节中的核心行动';
 
 -- ----------------------------
+-- Table structure for worlds
+-- ----------------------------
+DROP TABLE IF EXISTS `worlds`;
+CREATE TABLE `worlds`  (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `user_id` bigint NOT NULL,
+  `name` varchar(80) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+  `tagline` varchar(180) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+  `themes` json NULL,
+  `creative_intent` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+  `notes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL,
+  `status` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+  `version` int NOT NULL DEFAULT 0,
+  `published_at` datetime(6) NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `deleted_at` datetime(6) NULL,
+  `last_edited_by` bigint NULL,
+  `last_edited_at` datetime(6) NULL,
+  PRIMARY KEY (`id`) USING BTREE,
+  KEY `idx_worlds_user_status`(`user_id`, `status`),
+  KEY `idx_worlds_status_updated`(`status`, `updated_at`),
+  CONSTRAINT `fk_worlds_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci ROW_FORMAT = Dynamic;
+
+-- ----------------------------
+-- Table structure for world_modules
+-- ----------------------------
+DROP TABLE IF EXISTS `world_modules`;
+CREATE TABLE `world_modules`  (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `world_id` bigint NOT NULL,
+  `module_key` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+  `fields` json NULL,
+  `status` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+  `content_hash` char(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL,
+  `full_content` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NULL,
+  `full_content_updated_at` datetime(6) NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `last_edited_by` bigint NULL,
+  `last_edited_at` datetime(6) NULL,
+  PRIMARY KEY (`id`) USING BTREE,
+  UNIQUE KEY `uk_world_module_key`(`world_id`, `module_key`),
+  KEY `idx_world_modules_world`(`world_id`),
+  KEY `idx_world_modules_status`(`status`),
+  CONSTRAINT `fk_world_modules_world` FOREIGN KEY (`world_id`) REFERENCES `worlds` (`id`) ON DELETE CASCADE
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci ROW_FORMAT = Dynamic;
+
+-- ----------------------------
 -- Version 2.3 Changes
 -- ----------------------------
 

--- a/backend/src/main/java/com/example/ainovel/controller/WorldController.java
+++ b/backend/src/main/java/com/example/ainovel/controller/WorldController.java
@@ -1,0 +1,164 @@
+package com.example.ainovel.controller;
+
+import com.example.ainovel.dto.world.WorldDetailResponse;
+import com.example.ainovel.dto.world.WorldModulesBatchUpdateRequest;
+import com.example.ainovel.dto.world.WorldModuleResponse;
+import com.example.ainovel.dto.world.WorldModuleSummary;
+import com.example.ainovel.dto.world.WorldModuleUpdateRequest;
+import com.example.ainovel.dto.world.WorldPublishPreviewResponse;
+import com.example.ainovel.dto.world.WorldPublishResponse;
+import com.example.ainovel.dto.world.WorldSummaryResponse;
+import com.example.ainovel.dto.world.WorldUpsertRequest;
+import com.example.ainovel.model.User;
+import com.example.ainovel.model.world.WorldModule;
+import com.example.ainovel.model.world.WorldModuleStatus;
+import com.example.ainovel.model.world.WorldStatus;
+import com.example.ainovel.service.world.WorldAggregate;
+import com.example.ainovel.service.world.WorldDtoMapper;
+import com.example.ainovel.service.world.WorldModuleService;
+import com.example.ainovel.service.world.WorldPublicationService;
+import com.example.ainovel.service.world.WorldService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1/worlds")
+public class WorldController {
+
+    private final WorldService worldService;
+    private final WorldModuleService worldModuleService;
+    private final WorldPublicationService worldPublicationService;
+    private final WorldDtoMapper worldDtoMapper;
+
+    public WorldController(WorldService worldService,
+                           WorldModuleService worldModuleService,
+                           WorldPublicationService worldPublicationService,
+                           WorldDtoMapper worldDtoMapper) {
+        this.worldService = worldService;
+        this.worldModuleService = worldModuleService;
+        this.worldPublicationService = worldPublicationService;
+        this.worldDtoMapper = worldDtoMapper;
+    }
+
+    @PostMapping
+    public ResponseEntity<WorldDetailResponse> createWorld(@AuthenticationPrincipal User user,
+                                                           @RequestBody WorldUpsertRequest request) {
+        WorldAggregate aggregate = worldService.createWorld(user, request);
+        WorldDetailResponse response = worldDtoMapper.toDetail(aggregate.world(), aggregate.modules());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<WorldSummaryResponse>> listWorlds(@AuthenticationPrincipal User user,
+                                                                 @RequestParam(value = "status", required = false) String status) {
+        WorldStatus filter = parseStatus(status);
+        List<WorldAggregate> aggregates = worldService.listWorlds(user.getId(), filter);
+        List<WorldSummaryResponse> responses = aggregates.stream()
+                .map(aggregate -> worldDtoMapper.toSummary(aggregate.world(), aggregate.modules()))
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/{worldId}")
+    public ResponseEntity<WorldDetailResponse> getWorld(@PathVariable Long worldId,
+                                                        @AuthenticationPrincipal User user) {
+        WorldAggregate aggregate = worldService.getWorld(worldId, user.getId());
+        WorldDetailResponse response = worldDtoMapper.toDetail(aggregate.world(), aggregate.modules());
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{worldId}")
+    public ResponseEntity<WorldDetailResponse> updateWorld(@PathVariable Long worldId,
+                                                           @AuthenticationPrincipal User user,
+                                                           @RequestBody WorldUpsertRequest request) {
+        WorldAggregate aggregate = worldService.updateWorld(worldId, user.getId(), request);
+        WorldDetailResponse response = worldDtoMapper.toDetail(aggregate.world(), aggregate.modules());
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{worldId}")
+    public ResponseEntity<Void> deleteWorld(@PathVariable Long worldId,
+                                            @AuthenticationPrincipal User user) {
+        worldService.deleteWorld(worldId, user.getId());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{worldId}/modules/{moduleKey}")
+    public ResponseEntity<WorldModuleResponse> updateModule(@PathVariable Long worldId,
+                                                            @PathVariable String moduleKey,
+                                                            @AuthenticationPrincipal User user,
+                                                            @RequestBody WorldModuleUpdateRequest request) {
+        WorldModule module = worldModuleService.updateModule(worldId, user.getId(), moduleKey, request);
+        return ResponseEntity.ok(worldDtoMapper.toModuleResponse(module));
+    }
+
+    @PutMapping("/{worldId}/modules")
+    public ResponseEntity<List<WorldModuleResponse>> updateModules(@PathVariable Long worldId,
+                                                                   @AuthenticationPrincipal User user,
+                                                                   @RequestBody WorldModulesBatchUpdateRequest request) {
+        List<WorldModule> modules = worldModuleService.updateModules(worldId, user.getId(), request);
+        return ResponseEntity.ok(worldDtoMapper.toModuleResponses(modules));
+    }
+
+    @GetMapping("/{worldId}/publish/preview")
+    public ResponseEntity<WorldPublishPreviewResponse> previewPublish(@PathVariable Long worldId,
+                                                                      @AuthenticationPrincipal User user) {
+        WorldPublicationService.PublicationAnalysis analysis = worldPublicationService.preview(worldId, user.getId());
+        return ResponseEntity.ok(toPreviewResponse(analysis));
+    }
+
+    @PostMapping("/{worldId}/publish")
+    public ResponseEntity<WorldPublishResponse> publish(@PathVariable Long worldId,
+                                                        @AuthenticationPrincipal User user) {
+        WorldPublicationService.PublicationAnalysis analysis = worldPublicationService.preparePublish(worldId, user.getId());
+        WorldPublishResponse response = new WorldPublishResponse()
+                .setWorldId(analysis.world().getId())
+                .setModulesToGenerate(toModuleSummaries(analysis.modulesToGenerate()))
+                .setModulesToReuse(toModuleSummaries(analysis.modulesToReuse()));
+        return ResponseEntity.ok(response);
+    }
+
+    private WorldPublishPreviewResponse toPreviewResponse(WorldPublicationService.PublicationAnalysis analysis) {
+        Map<String, WorldModuleStatus> statusMap = new LinkedHashMap<>();
+        for (WorldModule module : analysis.modules()) {
+            statusMap.put(module.getModuleKey(), module.getStatus());
+        }
+        WorldPublishPreviewResponse response = new WorldPublishPreviewResponse()
+                .setReady(analysis.missingFields().isEmpty())
+                .setModuleStatuses(statusMap)
+                .setMissingFields(worldDtoMapper.buildMissingFields(analysis.missingFields()))
+                .setModulesToGenerate(toModuleSummaries(analysis.modulesToGenerate()))
+                .setModulesToReuse(toModuleSummaries(analysis.modulesToReuse()));
+        return response;
+    }
+
+    private List<WorldModuleSummary> toModuleSummaries(List<WorldModule> modules) {
+        return modules.stream()
+                .map(module -> worldDtoMapper.toModuleSummary(module.getModuleKey()))
+                .collect(Collectors.toList());
+    }
+
+    private WorldStatus parseStatus(String statusParam) {
+        if (statusParam == null || statusParam.isBlank() || "all".equalsIgnoreCase(statusParam)) {
+            return null;
+        }
+        return WorldStatus.fromString(statusParam)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "无效的状态参数"));
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/world/WorldDetailResponse.java
+++ b/backend/src/main/java/com/example/ainovel/dto/world/WorldDetailResponse.java
@@ -1,0 +1,153 @@
+package com.example.ainovel.dto.world;
+
+import com.example.ainovel.model.world.WorldStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class WorldDetailResponse {
+
+    private WorldInfo world;
+    private List<WorldModuleResponse> modules;
+
+    public WorldInfo getWorld() {
+        return world;
+    }
+
+    public WorldDetailResponse setWorld(WorldInfo world) {
+        this.world = world;
+        return this;
+    }
+
+    public List<WorldModuleResponse> getModules() {
+        return modules;
+    }
+
+    public WorldDetailResponse setModules(List<WorldModuleResponse> modules) {
+        this.modules = modules;
+        return this;
+    }
+
+    public static class WorldInfo {
+        private Long id;
+        private String name;
+        private String tagline;
+        private List<String> themes;
+        private String creativeIntent;
+        private String notes;
+        private WorldStatus status;
+        private Integer version;
+        private LocalDateTime publishedAt;
+        private LocalDateTime updatedAt;
+        private LocalDateTime createdAt;
+        private LocalDateTime lastEditedAt;
+
+        public Long getId() {
+            return id;
+        }
+
+        public WorldInfo setId(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public WorldInfo setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public String getTagline() {
+            return tagline;
+        }
+
+        public WorldInfo setTagline(String tagline) {
+            this.tagline = tagline;
+            return this;
+        }
+
+        public List<String> getThemes() {
+            return themes;
+        }
+
+        public WorldInfo setThemes(List<String> themes) {
+            this.themes = themes;
+            return this;
+        }
+
+        public String getCreativeIntent() {
+            return creativeIntent;
+        }
+
+        public WorldInfo setCreativeIntent(String creativeIntent) {
+            this.creativeIntent = creativeIntent;
+            return this;
+        }
+
+        public String getNotes() {
+            return notes;
+        }
+
+        public WorldInfo setNotes(String notes) {
+            this.notes = notes;
+            return this;
+        }
+
+        public WorldStatus getStatus() {
+            return status;
+        }
+
+        public WorldInfo setStatus(WorldStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        public Integer getVersion() {
+            return version;
+        }
+
+        public WorldInfo setVersion(Integer version) {
+            this.version = version;
+            return this;
+        }
+
+        public LocalDateTime getPublishedAt() {
+            return publishedAt;
+        }
+
+        public WorldInfo setPublishedAt(LocalDateTime publishedAt) {
+            this.publishedAt = publishedAt;
+            return this;
+        }
+
+        public LocalDateTime getUpdatedAt() {
+            return updatedAt;
+        }
+
+        public WorldInfo setUpdatedAt(LocalDateTime updatedAt) {
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
+        public LocalDateTime getCreatedAt() {
+            return createdAt;
+        }
+
+        public WorldInfo setCreatedAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public LocalDateTime getLastEditedAt() {
+            return lastEditedAt;
+        }
+
+        public WorldInfo setLastEditedAt(LocalDateTime lastEditedAt) {
+            this.lastEditedAt = lastEditedAt;
+            return this;
+        }
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/world/WorldModuleResponse.java
+++ b/backend/src/main/java/com/example/ainovel/dto/world/WorldModuleResponse.java
@@ -1,0 +1,80 @@
+package com.example.ainovel.dto.world;
+
+import com.example.ainovel.model.world.WorldModuleStatus;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public class WorldModuleResponse {
+
+    private String key;
+    private String label;
+    private WorldModuleStatus status;
+    private Map<String, String> fields;
+    private String contentHash;
+    private String fullContent;
+    private LocalDateTime fullContentUpdatedAt;
+
+    public String getKey() {
+        return key;
+    }
+
+    public WorldModuleResponse setKey(String key) {
+        this.key = key;
+        return this;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public WorldModuleResponse setLabel(String label) {
+        this.label = label;
+        return this;
+    }
+
+    public WorldModuleStatus getStatus() {
+        return status;
+    }
+
+    public WorldModuleResponse setStatus(WorldModuleStatus status) {
+        this.status = status;
+        return this;
+    }
+
+    public Map<String, String> getFields() {
+        return fields;
+    }
+
+    public WorldModuleResponse setFields(Map<String, String> fields) {
+        this.fields = fields;
+        return this;
+    }
+
+    public String getContentHash() {
+        return contentHash;
+    }
+
+    public WorldModuleResponse setContentHash(String contentHash) {
+        this.contentHash = contentHash;
+        return this;
+    }
+
+    public String getFullContent() {
+        return fullContent;
+    }
+
+    public WorldModuleResponse setFullContent(String fullContent) {
+        this.fullContent = fullContent;
+        return this;
+    }
+
+    public LocalDateTime getFullContentUpdatedAt() {
+        return fullContentUpdatedAt;
+    }
+
+    public WorldModuleResponse setFullContentUpdatedAt(LocalDateTime fullContentUpdatedAt) {
+        this.fullContentUpdatedAt = fullContentUpdatedAt;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/world/WorldModuleSummary.java
+++ b/backend/src/main/java/com/example/ainovel/dto/world/WorldModuleSummary.java
@@ -1,0 +1,33 @@
+package com.example.ainovel.dto.world;
+
+public class WorldModuleSummary {
+
+    private String key;
+    private String label;
+
+    public WorldModuleSummary() {
+    }
+
+    public WorldModuleSummary(String key, String label) {
+        this.key = key;
+        this.label = label;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public WorldModuleSummary setKey(String key) {
+        this.key = key;
+        return this;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public WorldModuleSummary setLabel(String label) {
+        this.label = label;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/world/WorldModuleUpdateRequest.java
+++ b/backend/src/main/java/com/example/ainovel/dto/world/WorldModuleUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.example.ainovel.dto.world;
+
+import java.util.Map;
+
+public class WorldModuleUpdateRequest {
+
+    private Map<String, String> fields;
+
+    public Map<String, String> getFields() {
+        return fields;
+    }
+
+    public WorldModuleUpdateRequest setFields(Map<String, String> fields) {
+        this.fields = fields;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/world/WorldModulesBatchUpdateRequest.java
+++ b/backend/src/main/java/com/example/ainovel/dto/world/WorldModulesBatchUpdateRequest.java
@@ -1,0 +1,41 @@
+package com.example.ainovel.dto.world;
+
+import java.util.List;
+import java.util.Map;
+
+public class WorldModulesBatchUpdateRequest {
+
+    private List<ModuleUpdate> modules;
+
+    public List<ModuleUpdate> getModules() {
+        return modules;
+    }
+
+    public WorldModulesBatchUpdateRequest setModules(List<ModuleUpdate> modules) {
+        this.modules = modules;
+        return this;
+    }
+
+    public static class ModuleUpdate {
+        private String key;
+        private Map<String, String> fields;
+
+        public String getKey() {
+            return key;
+        }
+
+        public ModuleUpdate setKey(String key) {
+            this.key = key;
+            return this;
+        }
+
+        public Map<String, String> getFields() {
+            return fields;
+        }
+
+        public ModuleUpdate setFields(Map<String, String> fields) {
+            this.fields = fields;
+            return this;
+        }
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/world/WorldPublishPreviewResponse.java
+++ b/backend/src/main/java/com/example/ainovel/dto/world/WorldPublishPreviewResponse.java
@@ -1,0 +1,103 @@
+package com.example.ainovel.dto.world;
+
+import com.example.ainovel.model.world.WorldModuleStatus;
+
+import java.util.List;
+import java.util.Map;
+
+public class WorldPublishPreviewResponse {
+
+    private boolean ready;
+    private Map<String, WorldModuleStatus> moduleStatuses;
+    private List<MissingField> missingFields;
+    private List<WorldModuleSummary> modulesToGenerate;
+    private List<WorldModuleSummary> modulesToReuse;
+
+    public boolean isReady() {
+        return ready;
+    }
+
+    public WorldPublishPreviewResponse setReady(boolean ready) {
+        this.ready = ready;
+        return this;
+    }
+
+    public Map<String, WorldModuleStatus> getModuleStatuses() {
+        return moduleStatuses;
+    }
+
+    public WorldPublishPreviewResponse setModuleStatuses(Map<String, WorldModuleStatus> moduleStatuses) {
+        this.moduleStatuses = moduleStatuses;
+        return this;
+    }
+
+    public List<MissingField> getMissingFields() {
+        return missingFields;
+    }
+
+    public WorldPublishPreviewResponse setMissingFields(List<MissingField> missingFields) {
+        this.missingFields = missingFields;
+        return this;
+    }
+
+    public List<WorldModuleSummary> getModulesToGenerate() {
+        return modulesToGenerate;
+    }
+
+    public WorldPublishPreviewResponse setModulesToGenerate(List<WorldModuleSummary> modulesToGenerate) {
+        this.modulesToGenerate = modulesToGenerate;
+        return this;
+    }
+
+    public List<WorldModuleSummary> getModulesToReuse() {
+        return modulesToReuse;
+    }
+
+    public WorldPublishPreviewResponse setModulesToReuse(List<WorldModuleSummary> modulesToReuse) {
+        this.modulesToReuse = modulesToReuse;
+        return this;
+    }
+
+    public static class MissingField {
+        private String moduleKey;
+        private String moduleLabel;
+        private String fieldKey;
+        private String fieldLabel;
+
+        public String getModuleKey() {
+            return moduleKey;
+        }
+
+        public MissingField setModuleKey(String moduleKey) {
+            this.moduleKey = moduleKey;
+            return this;
+        }
+
+        public String getModuleLabel() {
+            return moduleLabel;
+        }
+
+        public MissingField setModuleLabel(String moduleLabel) {
+            this.moduleLabel = moduleLabel;
+            return this;
+        }
+
+        public String getFieldKey() {
+            return fieldKey;
+        }
+
+        public MissingField setFieldKey(String fieldKey) {
+            this.fieldKey = fieldKey;
+            return this;
+        }
+
+        public String getFieldLabel() {
+            return fieldLabel;
+        }
+
+        public MissingField setFieldLabel(String fieldLabel) {
+            this.fieldLabel = fieldLabel;
+            return this;
+        }
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/world/WorldPublishResponse.java
+++ b/backend/src/main/java/com/example/ainovel/dto/world/WorldPublishResponse.java
@@ -1,0 +1,37 @@
+package com.example.ainovel.dto.world;
+
+import java.util.List;
+
+public class WorldPublishResponse {
+
+    private Long worldId;
+    private List<WorldModuleSummary> modulesToGenerate;
+    private List<WorldModuleSummary> modulesToReuse;
+
+    public Long getWorldId() {
+        return worldId;
+    }
+
+    public WorldPublishResponse setWorldId(Long worldId) {
+        this.worldId = worldId;
+        return this;
+    }
+
+    public List<WorldModuleSummary> getModulesToGenerate() {
+        return modulesToGenerate;
+    }
+
+    public WorldPublishResponse setModulesToGenerate(List<WorldModuleSummary> modulesToGenerate) {
+        this.modulesToGenerate = modulesToGenerate;
+        return this;
+    }
+
+    public List<WorldModuleSummary> getModulesToReuse() {
+        return modulesToReuse;
+    }
+
+    public WorldPublishResponse setModulesToReuse(List<WorldModuleSummary> modulesToReuse) {
+        this.modulesToReuse = modulesToReuse;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/world/WorldSummaryResponse.java
+++ b/backend/src/main/java/com/example/ainovel/dto/world/WorldSummaryResponse.java
@@ -1,0 +1,102 @@
+package com.example.ainovel.dto.world;
+
+import com.example.ainovel.model.world.WorldModuleStatus;
+import com.example.ainovel.model.world.WorldStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class WorldSummaryResponse {
+
+    private Long id;
+    private String name;
+    private String tagline;
+    private List<String> themes;
+    private WorldStatus status;
+    private Integer version;
+    private LocalDateTime updatedAt;
+    private LocalDateTime publishedAt;
+    private Map<String, WorldModuleStatus> moduleProgress;
+
+    public Long getId() {
+        return id;
+    }
+
+    public WorldSummaryResponse setId(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public WorldSummaryResponse setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getTagline() {
+        return tagline;
+    }
+
+    public WorldSummaryResponse setTagline(String tagline) {
+        this.tagline = tagline;
+        return this;
+    }
+
+    public List<String> getThemes() {
+        return themes;
+    }
+
+    public WorldSummaryResponse setThemes(List<String> themes) {
+        this.themes = themes;
+        return this;
+    }
+
+    public WorldStatus getStatus() {
+        return status;
+    }
+
+    public WorldSummaryResponse setStatus(WorldStatus status) {
+        this.status = status;
+        return this;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public WorldSummaryResponse setVersion(Integer version) {
+        this.version = version;
+        return this;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public WorldSummaryResponse setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+        return this;
+    }
+
+    public LocalDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public WorldSummaryResponse setPublishedAt(LocalDateTime publishedAt) {
+        this.publishedAt = publishedAt;
+        return this;
+    }
+
+    public Map<String, WorldModuleStatus> getModuleProgress() {
+        return moduleProgress;
+    }
+
+    public WorldSummaryResponse setModuleProgress(Map<String, WorldModuleStatus> moduleProgress) {
+        this.moduleProgress = moduleProgress;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/dto/world/WorldUpsertRequest.java
+++ b/backend/src/main/java/com/example/ainovel/dto/world/WorldUpsertRequest.java
@@ -1,0 +1,57 @@
+package com.example.ainovel.dto.world;
+
+import java.util.List;
+
+public class WorldUpsertRequest {
+
+    private String name;
+    private String tagline;
+    private List<String> themes;
+    private String creativeIntent;
+    private String notes;
+
+    public String getName() {
+        return name;
+    }
+
+    public WorldUpsertRequest setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getTagline() {
+        return tagline;
+    }
+
+    public WorldUpsertRequest setTagline(String tagline) {
+        this.tagline = tagline;
+        return this;
+    }
+
+    public List<String> getThemes() {
+        return themes;
+    }
+
+    public WorldUpsertRequest setThemes(List<String> themes) {
+        this.themes = themes;
+        return this;
+    }
+
+    public String getCreativeIntent() {
+        return creativeIntent;
+    }
+
+    public WorldUpsertRequest setCreativeIntent(String creativeIntent) {
+        this.creativeIntent = creativeIntent;
+        return this;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public WorldUpsertRequest setNotes(String notes) {
+        this.notes = notes;
+        return this;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/model/world/World.java
+++ b/backend/src/main/java/com/example/ainovel/model/world/World.java
@@ -1,0 +1,216 @@
+package com.example.ainovel.model.world;
+
+import com.example.ainovel.model.User;
+import com.example.ainovel.model.world.converter.StringListJsonConverter;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "worlds")
+@SQLDelete(sql = "UPDATE worlds SET deleted_at = NOW() WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class World {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 80)
+    private String name;
+
+    @Column(length = 180, nullable = false)
+    private String tagline;
+
+    @Column(columnDefinition = "JSON")
+    @Convert(converter = StringListJsonConverter.class)
+    private List<String> themes = new ArrayList<>();
+
+    @Column(name = "creative_intent", columnDefinition = "TEXT", nullable = false)
+    private String creativeIntent;
+
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private WorldStatus status = WorldStatus.DRAFT;
+
+    @Column(nullable = false)
+    private Integer version = 0;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "last_edited_by")
+    private Long lastEditedBy;
+
+    @Column(name = "last_edited_at")
+    private LocalDateTime lastEditedAt;
+
+    @OneToMany(mappedBy = "world", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WorldModule> modules = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getTagline() {
+        return tagline;
+    }
+
+    public void setTagline(String tagline) {
+        this.tagline = tagline;
+    }
+
+    public List<String> getThemes() {
+        return themes;
+    }
+
+    public void setThemes(List<String> themes) {
+        this.themes = themes;
+    }
+
+    public String getCreativeIntent() {
+        return creativeIntent;
+    }
+
+    public void setCreativeIntent(String creativeIntent) {
+        this.creativeIntent = creativeIntent;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public WorldStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(WorldStatus status) {
+        this.status = status;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+    public LocalDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(LocalDateTime publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
+    public Long getLastEditedBy() {
+        return lastEditedBy;
+    }
+
+    public void setLastEditedBy(Long lastEditedBy) {
+        this.lastEditedBy = lastEditedBy;
+    }
+
+    public LocalDateTime getLastEditedAt() {
+        return lastEditedAt;
+    }
+
+    public void setLastEditedAt(LocalDateTime lastEditedAt) {
+        this.lastEditedAt = lastEditedAt;
+    }
+
+    public List<WorldModule> getModules() {
+        return modules;
+    }
+
+    public void setModules(List<WorldModule> modules) {
+        this.modules = modules;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/model/world/WorldModule.java
+++ b/backend/src/main/java/com/example/ainovel/model/world/WorldModule.java
@@ -1,0 +1,172 @@
+package com.example.ainovel.model.world;
+
+import com.example.ainovel.model.world.converter.StringMapJsonConverter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Entity
+@Table(name = "world_modules", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_world_module_key", columnNames = {"world_id", "module_key"})
+})
+public class WorldModule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "world_id", nullable = false)
+    @JsonIgnore
+    private World world;
+
+    @Column(name = "module_key", length = 32, nullable = false)
+    private String moduleKey;
+
+    @Column(columnDefinition = "JSON")
+    @Convert(converter = StringMapJsonConverter.class)
+    private Map<String, String> fields = new LinkedHashMap<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private WorldModuleStatus status = WorldModuleStatus.EMPTY;
+
+    @Column(name = "content_hash", length = 64)
+    private String contentHash;
+
+    @Lob
+    @Column(name = "full_content", columnDefinition = "LONGTEXT")
+    private String fullContent;
+
+    @Column(name = "full_content_updated_at")
+    private LocalDateTime fullContentUpdatedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "last_edited_by")
+    private Long lastEditedBy;
+
+    @Column(name = "last_edited_at")
+    private LocalDateTime lastEditedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public World getWorld() {
+        return world;
+    }
+
+    public void setWorld(World world) {
+        this.world = world;
+    }
+
+    public String getModuleKey() {
+        return moduleKey;
+    }
+
+    public void setModuleKey(String moduleKey) {
+        this.moduleKey = moduleKey;
+    }
+
+    public Map<String, String> getFields() {
+        return fields;
+    }
+
+    public void setFields(Map<String, String> fields) {
+        this.fields = fields;
+    }
+
+    public WorldModuleStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(WorldModuleStatus status) {
+        this.status = status;
+    }
+
+    public String getContentHash() {
+        return contentHash;
+    }
+
+    public void setContentHash(String contentHash) {
+        this.contentHash = contentHash;
+    }
+
+    public String getFullContent() {
+        return fullContent;
+    }
+
+    public void setFullContent(String fullContent) {
+        this.fullContent = fullContent;
+    }
+
+    public LocalDateTime getFullContentUpdatedAt() {
+        return fullContentUpdatedAt;
+    }
+
+    public void setFullContentUpdatedAt(LocalDateTime fullContentUpdatedAt) {
+        this.fullContentUpdatedAt = fullContentUpdatedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Long getLastEditedBy() {
+        return lastEditedBy;
+    }
+
+    public void setLastEditedBy(Long lastEditedBy) {
+        this.lastEditedBy = lastEditedBy;
+    }
+
+    public LocalDateTime getLastEditedAt() {
+        return lastEditedAt;
+    }
+
+    public void setLastEditedAt(LocalDateTime lastEditedAt) {
+        this.lastEditedAt = lastEditedAt;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/model/world/WorldModuleStatus.java
+++ b/backend/src/main/java/com/example/ainovel/model/world/WorldModuleStatus.java
@@ -1,0 +1,15 @@
+package com.example.ainovel.model.world;
+
+public enum WorldModuleStatus {
+    EMPTY,
+    IN_PROGRESS,
+    READY,
+    AWAITING_GENERATION,
+    GENERATING,
+    COMPLETED,
+    FAILED;
+
+    public boolean isReadyForPublish() {
+        return this == READY || this == AWAITING_GENERATION || this == COMPLETED;
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/model/world/WorldStatus.java
+++ b/backend/src/main/java/com/example/ainovel/model/world/WorldStatus.java
@@ -1,0 +1,24 @@
+package com.example.ainovel.model.world;
+
+import java.util.Locale;
+import java.util.Optional;
+
+public enum WorldStatus {
+    DRAFT,
+    GENERATING,
+    ACTIVE,
+    ARCHIVED;
+
+    public static Optional<WorldStatus> fromString(String value) {
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        for (WorldStatus status : values()) {
+            if (status.name().equals(normalized)) {
+                return Optional.of(status);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/model/world/converter/StringListJsonConverter.java
+++ b/backend/src/main/java/com/example/ainovel/model/world/converter/StringListJsonConverter.java
@@ -1,0 +1,44 @@
+package com.example.ainovel.model.world.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Converter
+public class StringListJsonConverter implements AttributeConverter<List<String>, String> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    static {
+        OBJECT_MAPPER.findAndRegisterModules();
+    }
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize string list", e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return new ArrayList<>();
+        }
+        try {
+            List<String> values = OBJECT_MAPPER.readValue(dbData, OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, String.class));
+            return new ArrayList<>(values);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize string list", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/model/world/converter/StringMapJsonConverter.java
+++ b/backend/src/main/java/com/example/ainovel/model/world/converter/StringMapJsonConverter.java
@@ -1,0 +1,47 @@
+package com.example.ainovel.model.world.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Converter
+public class StringMapJsonConverter implements AttributeConverter<Map<String, String>, String> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    static {
+        OBJECT_MAPPER.findAndRegisterModules();
+        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize map", e);
+        }
+    }
+
+    @Override
+    public Map<String, String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            Map<String, String> values = OBJECT_MAPPER.readValue(dbData, OBJECT_MAPPER.getTypeFactory()
+                    .constructMapType(LinkedHashMap.class, String.class, String.class));
+            return new LinkedHashMap<>(values);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize map", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/repository/WorldModuleRepository.java
+++ b/backend/src/main/java/com/example/ainovel/repository/WorldModuleRepository.java
@@ -1,0 +1,20 @@
+package com.example.ainovel.repository;
+
+import com.example.ainovel.model.world.WorldModule;
+import com.example.ainovel.model.world.WorldModuleStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface WorldModuleRepository extends JpaRepository<WorldModule, Long> {
+
+    List<WorldModule> findByWorldId(Long worldId);
+
+    List<WorldModule> findByWorldIdIn(Collection<Long> worldIds);
+
+    Optional<WorldModule> findByWorldIdAndModuleKey(Long worldId, String moduleKey);
+
+    long countByWorldIdAndStatusIn(Long worldId, Collection<WorldModuleStatus> statuses);
+}

--- a/backend/src/main/java/com/example/ainovel/repository/WorldRepository.java
+++ b/backend/src/main/java/com/example/ainovel/repository/WorldRepository.java
@@ -1,0 +1,17 @@
+package com.example.ainovel.repository;
+
+import com.example.ainovel.model.world.World;
+import com.example.ainovel.model.world.WorldStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WorldRepository extends JpaRepository<World, Long> {
+
+    Optional<World> findByIdAndUserId(Long id, Long userId);
+
+    List<World> findAllByUserIdOrderByUpdatedAtDesc(Long userId);
+
+    List<World> findAllByUserIdAndStatusOrderByUpdatedAtDesc(Long userId, WorldStatus status);
+}

--- a/backend/src/main/java/com/example/ainovel/service/world/WorldAggregate.java
+++ b/backend/src/main/java/com/example/ainovel/service/world/WorldAggregate.java
@@ -1,0 +1,9 @@
+package com.example.ainovel.service.world;
+
+import com.example.ainovel.model.world.World;
+import com.example.ainovel.model.world.WorldModule;
+
+import java.util.List;
+
+public record WorldAggregate(World world, List<WorldModule> modules) {
+}

--- a/backend/src/main/java/com/example/ainovel/service/world/WorldDtoMapper.java
+++ b/backend/src/main/java/com/example/ainovel/service/world/WorldDtoMapper.java
@@ -1,0 +1,127 @@
+package com.example.ainovel.service.world;
+
+import com.example.ainovel.dto.world.WorldDetailResponse;
+import com.example.ainovel.dto.world.WorldModuleResponse;
+import com.example.ainovel.dto.world.WorldModuleSummary;
+import com.example.ainovel.dto.world.WorldPublishPreviewResponse;
+import com.example.ainovel.dto.world.WorldSummaryResponse;
+import com.example.ainovel.model.world.World;
+import com.example.ainovel.model.world.WorldModule;
+import com.example.ainovel.model.world.WorldModuleStatus;
+import com.example.ainovel.worldbuilding.definition.WorldModuleDefinition;
+import com.example.ainovel.worldbuilding.definition.WorldModuleDefinitionRegistry;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class WorldDtoMapper {
+
+    private final WorldModuleDefinitionRegistry definitionRegistry;
+
+    public WorldDtoMapper(WorldModuleDefinitionRegistry definitionRegistry) {
+        this.definitionRegistry = definitionRegistry;
+    }
+
+    public WorldDetailResponse toDetail(World world, List<WorldModule> modules) {
+        WorldDetailResponse.WorldInfo info = new WorldDetailResponse.WorldInfo()
+                .setId(world.getId())
+                .setName(world.getName())
+                .setTagline(world.getTagline())
+                .setThemes(world.getThemes())
+                .setCreativeIntent(world.getCreativeIntent())
+                .setNotes(world.getNotes())
+                .setStatus(world.getStatus())
+                .setVersion(world.getVersion())
+                .setPublishedAt(world.getPublishedAt())
+                .setUpdatedAt(world.getUpdatedAt())
+                .setCreatedAt(world.getCreatedAt())
+                .setLastEditedAt(world.getLastEditedAt());
+
+        List<WorldModuleResponse> moduleResponses = sortModules(modules).stream()
+                .map(this::toModuleResponse)
+                .collect(Collectors.toList());
+
+        return new WorldDetailResponse()
+                .setWorld(info)
+                .setModules(moduleResponses);
+    }
+
+    public WorldSummaryResponse toSummary(World world, List<WorldModule> modules) {
+        Map<String, WorldModuleStatus> progress = new LinkedHashMap<>();
+        definitionRegistry.getAll().forEach(def -> progress.put(def.key(), WorldModuleStatus.EMPTY));
+        for (WorldModule module : modules) {
+            progress.put(module.getModuleKey(), module.getStatus());
+        }
+        return new WorldSummaryResponse()
+                .setId(world.getId())
+                .setName(world.getName())
+                .setTagline(world.getTagline())
+                .setThemes(world.getThemes())
+                .setStatus(world.getStatus())
+                .setVersion(world.getVersion())
+                .setUpdatedAt(world.getUpdatedAt())
+                .setPublishedAt(world.getPublishedAt())
+                .setModuleProgress(progress);
+    }
+
+    public WorldModuleResponse toModuleResponse(WorldModule module) {
+        Map<String, String> fieldsCopy = module.getFields() == null ? new LinkedHashMap<>()
+                : new LinkedHashMap<>(module.getFields());
+        return new WorldModuleResponse()
+                .setKey(module.getModuleKey())
+                .setLabel(definitionRegistry.resolveLabel(module.getModuleKey()))
+                .setStatus(module.getStatus())
+                .setFields(fieldsCopy)
+                .setContentHash(module.getContentHash())
+                .setFullContent(module.getFullContent())
+                .setFullContentUpdatedAt(module.getFullContentUpdatedAt());
+    }
+
+    public WorldModuleSummary toModuleSummary(String moduleKey) {
+        return new WorldModuleSummary(moduleKey, definitionRegistry.resolveLabel(moduleKey));
+    }
+
+    public List<WorldModuleSummary> toModuleSummaries(List<WorldModule> modules) {
+        return sortModules(modules).stream()
+                .map(module -> new WorldModuleSummary(module.getModuleKey(),
+                        definitionRegistry.resolveLabel(module.getModuleKey())))
+                .collect(Collectors.toList());
+    }
+
+    public List<WorldModuleResponse> toModuleResponses(List<WorldModule> modules) {
+        return sortModules(modules).stream()
+                .map(this::toModuleResponse)
+                .collect(Collectors.toList());
+    }
+
+    public List<WorldPublishPreviewResponse.MissingField> buildMissingFields(
+            Map<String, List<String>> missingByModule) {
+        List<WorldPublishPreviewResponse.MissingField> results = new ArrayList<>();
+        missingByModule.forEach((moduleKey, fields) -> {
+            String moduleLabel = definitionRegistry.resolveLabel(moduleKey);
+            for (String fieldKey : fields) {
+                String fieldLabel = definitionRegistry.resolveFieldLabel(moduleKey, fieldKey).orElse(fieldKey);
+                results.add(new WorldPublishPreviewResponse.MissingField()
+                        .setModuleKey(moduleKey)
+                        .setModuleLabel(moduleLabel)
+                        .setFieldKey(fieldKey)
+                        .setFieldLabel(fieldLabel));
+            }
+        });
+        return results;
+    }
+
+    private List<WorldModule> sortModules(List<WorldModule> modules) {
+        Map<String, Integer> orderMap = definitionRegistry.getAll().stream()
+                .collect(Collectors.toMap(WorldModuleDefinition::key, WorldModuleDefinition::order));
+        return modules.stream()
+                .sorted(Comparator.comparingInt(module -> orderMap.getOrDefault(module.getModuleKey(), Integer.MAX_VALUE)))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/service/world/WorldModuleService.java
+++ b/backend/src/main/java/com/example/ainovel/service/world/WorldModuleService.java
@@ -1,0 +1,213 @@
+package com.example.ainovel.service.world;
+
+import com.example.ainovel.dto.world.WorldModulesBatchUpdateRequest;
+import com.example.ainovel.dto.world.WorldModuleUpdateRequest;
+import com.example.ainovel.exception.ResourceNotFoundException;
+import com.example.ainovel.model.world.World;
+import com.example.ainovel.model.world.WorldModule;
+import com.example.ainovel.model.world.WorldModuleStatus;
+import com.example.ainovel.model.world.WorldStatus;
+import com.example.ainovel.repository.WorldModuleRepository;
+import com.example.ainovel.repository.WorldRepository;
+import com.example.ainovel.worldbuilding.definition.WorldModuleDefinition;
+import com.example.ainovel.worldbuilding.definition.WorldModuleDefinitionRegistry;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.HexFormat;
+
+@Service
+@Transactional
+public class WorldModuleService {
+
+    private static final ObjectMapper HASH_OBJECT_MAPPER = new ObjectMapper();
+
+    static {
+        HASH_OBJECT_MAPPER.findAndRegisterModules();
+        HASH_OBJECT_MAPPER.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+    }
+
+    private final WorldRepository worldRepository;
+    private final WorldModuleRepository worldModuleRepository;
+    private final WorldModuleDefinitionRegistry definitionRegistry;
+
+    public WorldModuleService(WorldRepository worldRepository,
+                              WorldModuleRepository worldModuleRepository,
+                              WorldModuleDefinitionRegistry definitionRegistry) {
+        this.worldRepository = worldRepository;
+        this.worldModuleRepository = worldModuleRepository;
+        this.definitionRegistry = definitionRegistry;
+    }
+
+    public WorldModule updateModule(Long worldId, Long userId, String moduleKey, WorldModuleUpdateRequest request) {
+        World world = loadWorld(worldId, userId);
+        ensureEditable(world);
+        WorldModule module = worldModuleRepository.findByWorldIdAndModuleKey(worldId, moduleKey)
+                .orElseThrow(() -> new ResourceNotFoundException("指定模块不存在"));
+        boolean changed = applyFieldUpdates(world, module, request == null ? Map.of() : request.getFields(), userId);
+        if (changed) {
+            worldModuleRepository.save(module);
+            worldRepository.save(world);
+        }
+        return module;
+    }
+
+    public List<WorldModule> updateModules(Long worldId, Long userId, WorldModulesBatchUpdateRequest request) {
+        World world = loadWorld(worldId, userId);
+        ensureEditable(world);
+        List<WorldModule> modules = worldModuleRepository.findByWorldId(worldId);
+        Map<String, WorldModule> moduleMap = modules.stream()
+                .collect(java.util.stream.Collectors.toMap(WorldModule::getModuleKey, module -> module));
+        List<WorldModule> updated = new ArrayList<>();
+        if (request != null && request.getModules() != null) {
+            for (WorldModulesBatchUpdateRequest.ModuleUpdate update : request.getModules()) {
+                if (update == null || update.getKey() == null) {
+                    continue;
+                }
+                WorldModule module = moduleMap.get(update.getKey());
+                if (module == null) {
+                    throw new ResourceNotFoundException("模块 " + update.getKey() + " 不存在");
+                }
+                if (applyFieldUpdates(world, module, update.getFields(), userId)) {
+                    updated.add(module);
+                }
+            }
+        }
+        if (!updated.isEmpty()) {
+            worldModuleRepository.saveAll(updated);
+            worldRepository.save(world);
+        }
+        return modules;
+    }
+
+    private boolean applyFieldUpdates(World world, WorldModule module, Map<String, String> updates, Long userId) {
+        if (updates == null || updates.isEmpty()) {
+            return false;
+        }
+        LinkedHashMap<String, String> current = module.getFields() == null ? new LinkedHashMap<>()
+                : new LinkedHashMap<>(module.getFields());
+        boolean changed = false;
+        for (Map.Entry<String, String> entry : updates.entrySet()) {
+            String fieldKey = entry.getKey();
+            if (fieldKey == null) {
+                continue;
+            }
+            String value = entry.getValue();
+            if (value == null) {
+                continue;
+            }
+            WorldModuleDefinition.FieldDefinition fieldDefinition;
+            try {
+                fieldDefinition = definitionRegistry.requireField(module.getModuleKey(), fieldKey);
+            } catch (IllegalArgumentException e) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+            }
+            String trimmed = value.trim();
+            if (trimmed.isEmpty()) {
+                if (current.remove(fieldKey) != null) {
+                    changed = true;
+                }
+                continue;
+            }
+            validateLength(trimmed, fieldDefinition);
+            String existing = current.get(fieldKey);
+            if (!Objects.equals(existing, trimmed)) {
+                current.put(fieldKey, trimmed);
+                changed = true;
+            }
+        }
+        if (!changed) {
+            return false;
+        }
+        module.setFields(current);
+        String newHash = computeContentHash(current);
+        boolean contentChanged = !Objects.equals(module.getContentHash(), newHash);
+        module.setContentHash(newHash);
+        LocalDateTime now = LocalDateTime.now();
+        module.setLastEditedBy(userId);
+        module.setLastEditedAt(now);
+        WorldModuleStatus newStatus = determineStatus(world, module.getModuleKey(), current, contentChanged);
+        module.setStatus(newStatus);
+        if (contentChanged && world.getStatus() == WorldStatus.ACTIVE) {
+            world.setStatus(WorldStatus.DRAFT);
+        }
+        if (contentChanged) {
+            world.setLastEditedBy(userId);
+            world.setLastEditedAt(now);
+        }
+        return true;
+    }
+
+    private void validateLength(String value, WorldModuleDefinition.FieldDefinition fieldDefinition) {
+        int length = value.length();
+        if (fieldDefinition.minLength() > 0 && length < fieldDefinition.minLength()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    fieldDefinition.label() + " 内容至少需要 " + fieldDefinition.minLength() + " 字");
+        }
+        if (fieldDefinition.maxLength() > 0 && length > fieldDefinition.maxLength()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    fieldDefinition.label() + " 内容需不超过 " + fieldDefinition.maxLength() + " 字");
+        }
+    }
+
+    private WorldModuleStatus determineStatus(World world, String moduleKey, Map<String, String> fields, boolean contentChanged) {
+        WorldModuleDefinition definition = definitionRegistry.requireModule(moduleKey);
+        boolean anyFilled = false;
+        boolean allRequiredFilled = true;
+        for (WorldModuleDefinition.FieldDefinition field : definition.fields()) {
+            String value = fields.get(field.key());
+            if (value != null && !value.isBlank()) {
+                anyFilled = true;
+            } else if (field.required()) {
+                allRequiredFilled = false;
+            }
+        }
+        if (!anyFilled) {
+            return WorldModuleStatus.EMPTY;
+        }
+        if (allRequiredFilled) {
+            if (world.getVersion() != null && world.getVersion() > 0 && contentChanged) {
+                return WorldModuleStatus.AWAITING_GENERATION;
+            }
+            return WorldModuleStatus.READY;
+        }
+        return WorldModuleStatus.IN_PROGRESS;
+    }
+
+    private World loadWorld(Long worldId, Long userId) {
+        return worldRepository.findByIdAndUserId(worldId, userId)
+                .orElseThrow(() -> new ResourceNotFoundException("世界不存在或无权访问"));
+    }
+
+    private void ensureEditable(World world) {
+        if (world.getStatus() == WorldStatus.GENERATING) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "世界正在生成中，无法修改");
+        }
+    }
+
+    private String computeContentHash(Map<String, String> fields) {
+        if (fields == null || fields.isEmpty()) {
+            return null;
+        }
+        try {
+            byte[] json = HASH_OBJECT_MAPPER.writeValueAsBytes(fields);
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(json));
+        } catch (JsonProcessingException | NoSuchAlgorithmException e) {
+            throw new IllegalStateException("无法计算内容哈希", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/service/world/WorldPublicationService.java
+++ b/backend/src/main/java/com/example/ainovel/service/world/WorldPublicationService.java
@@ -1,0 +1,144 @@
+package com.example.ainovel.service.world;
+
+import com.example.ainovel.exception.ResourceNotFoundException;
+import com.example.ainovel.model.world.World;
+import com.example.ainovel.model.world.WorldModule;
+import com.example.ainovel.model.world.WorldModuleStatus;
+import com.example.ainovel.model.world.WorldStatus;
+import com.example.ainovel.repository.WorldModuleRepository;
+import com.example.ainovel.repository.WorldRepository;
+import com.example.ainovel.worldbuilding.definition.WorldModuleDefinition;
+import com.example.ainovel.worldbuilding.definition.WorldModuleDefinitionRegistry;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class WorldPublicationService {
+
+    private final WorldRepository worldRepository;
+    private final WorldModuleRepository worldModuleRepository;
+    private final WorldModuleDefinitionRegistry definitionRegistry;
+
+    public WorldPublicationService(WorldRepository worldRepository,
+                                   WorldModuleRepository worldModuleRepository,
+                                   WorldModuleDefinitionRegistry definitionRegistry) {
+        this.worldRepository = worldRepository;
+        this.worldModuleRepository = worldModuleRepository;
+        this.definitionRegistry = definitionRegistry;
+    }
+
+    @Transactional(readOnly = true)
+    public PublicationAnalysis preview(Long worldId, Long userId) {
+        World world = loadWorld(worldId, userId);
+        List<WorldModule> modules = worldModuleRepository.findByWorldId(worldId);
+        return analyse(world, modules);
+    }
+
+    public PublicationAnalysis preparePublish(Long worldId, Long userId) {
+        World world = loadWorld(worldId, userId);
+        if (world.getStatus() == WorldStatus.GENERATING) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "世界正在生成中，无法再次发布");
+        }
+        List<WorldModule> modules = worldModuleRepository.findByWorldId(worldId);
+        PublicationAnalysis analysis = analyse(world, modules);
+        if (!analysis.missingFields().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "存在未填写完整的模块字段");
+        }
+        if (analysis.modulesToGenerate().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "没有需要生成的模块");
+        }
+        LocalDateTime now = LocalDateTime.now();
+        world.setStatus(WorldStatus.GENERATING);
+        world.setLastEditedBy(userId);
+        world.setLastEditedAt(now);
+        for (WorldModule module : analysis.modulesToGenerate()) {
+            module.setStatus(WorldModuleStatus.AWAITING_GENERATION);
+            module.setLastEditedBy(userId);
+            module.setLastEditedAt(now);
+        }
+        worldRepository.save(world);
+        worldModuleRepository.saveAll(analysis.modulesToGenerate());
+        return analysis;
+    }
+
+    private PublicationAnalysis analyse(World world, List<WorldModule> modules) {
+        Map<String, WorldModule> moduleMap = modules.stream()
+                .collect(Collectors.toMap(WorldModule::getModuleKey, module -> module));
+        Map<String, List<String>> missing = new LinkedHashMap<>();
+        Set<WorldModule> toGenerate = new LinkedHashSet<>();
+        List<WorldModule> toReuse = new ArrayList<>();
+
+        for (WorldModuleDefinition definition : definitionRegistry.getAll()) {
+            WorldModule module = moduleMap.get(definition.key());
+            if (module == null) {
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                        "缺少模块数据: " + definition.key());
+            }
+            List<String> missingFields = collectMissingFields(definition, module);
+            if (!missingFields.isEmpty()) {
+                missing.put(definition.key(), missingFields);
+            }
+            if (shouldGenerate(world, module)) {
+                toGenerate.add(module);
+            } else if (module.getStatus() == WorldModuleStatus.COMPLETED) {
+                toReuse.add(module);
+            }
+        }
+        return new PublicationAnalysis(world, modules, missing, new ArrayList<>(toGenerate), toReuse);
+    }
+
+    private List<String> collectMissingFields(WorldModuleDefinition definition, WorldModule module) {
+        List<String> result = new ArrayList<>();
+        Map<String, String> fields = module.getFields();
+        for (WorldModuleDefinition.FieldDefinition field : definition.fields()) {
+            String value = fields == null ? null : fields.get(field.key());
+            if (!field.required()) {
+                continue;
+            }
+            if (value == null || value.isBlank()) {
+                result.add(field.key());
+            }
+        }
+        return result;
+    }
+
+    private boolean shouldGenerate(World world, WorldModule module) {
+        WorldModuleStatus status = module.getStatus();
+        if (world.getVersion() == null || world.getVersion() == 0) {
+            return status == WorldModuleStatus.READY || status == WorldModuleStatus.AWAITING_GENERATION;
+        }
+        if (status == WorldModuleStatus.AWAITING_GENERATION || status == WorldModuleStatus.READY) {
+            return true;
+        }
+        if (status == WorldModuleStatus.FAILED) {
+            return true;
+        }
+        return false;
+    }
+
+    private World loadWorld(Long worldId, Long userId) {
+        return worldRepository.findByIdAndUserId(worldId, userId)
+                .orElseThrow(() -> new ResourceNotFoundException("世界不存在或无权访问"));
+    }
+
+    public record PublicationAnalysis(
+            World world,
+            List<WorldModule> modules,
+            Map<String, List<String>> missingFields,
+            List<WorldModule> modulesToGenerate,
+            List<WorldModule> modulesToReuse
+    ) {
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/service/world/WorldService.java
+++ b/backend/src/main/java/com/example/ainovel/service/world/WorldService.java
@@ -1,0 +1,223 @@
+package com.example.ainovel.service.world;
+
+import com.example.ainovel.dto.world.WorldUpsertRequest;
+import com.example.ainovel.exception.ResourceNotFoundException;
+import com.example.ainovel.model.User;
+import com.example.ainovel.model.world.World;
+import com.example.ainovel.model.world.WorldModule;
+import com.example.ainovel.model.world.WorldModuleStatus;
+import com.example.ainovel.model.world.WorldStatus;
+import com.example.ainovel.repository.WorldModuleRepository;
+import com.example.ainovel.repository.WorldRepository;
+import com.example.ainovel.worldbuilding.definition.WorldModuleDefinition;
+import com.example.ainovel.worldbuilding.definition.WorldModuleDefinitionRegistry;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class WorldService {
+
+    private static final int MAX_THEMES = 5;
+    private static final int MIN_THEMES = 1;
+    private static final int MAX_THEME_LENGTH = 30;
+
+    private final WorldRepository worldRepository;
+    private final WorldModuleRepository worldModuleRepository;
+    private final WorldModuleDefinitionRegistry definitionRegistry;
+
+    public WorldService(WorldRepository worldRepository,
+                        WorldModuleRepository worldModuleRepository,
+                        WorldModuleDefinitionRegistry definitionRegistry) {
+        this.worldRepository = worldRepository;
+        this.worldModuleRepository = worldModuleRepository;
+        this.definitionRegistry = definitionRegistry;
+    }
+
+    public WorldAggregate createWorld(User user, WorldUpsertRequest request) {
+        validateBasicInfo(request);
+        World world = new World();
+        world.setUser(user);
+        applyBasicInfo(world, request);
+        world.setStatus(WorldStatus.DRAFT);
+        world.setVersion(0);
+        LocalDateTime now = LocalDateTime.now();
+        world.setLastEditedBy(user.getId());
+        world.setLastEditedAt(now);
+
+        List<WorldModule> modules = new ArrayList<>();
+        for (WorldModuleDefinition definition : definitionRegistry.getAll()) {
+            WorldModule module = new WorldModule();
+            module.setWorld(world);
+            module.setModuleKey(definition.key());
+            module.setStatus(WorldModuleStatus.EMPTY);
+            module.setFields(new LinkedHashMap<>());
+            module.setLastEditedBy(user.getId());
+            module.setLastEditedAt(now);
+            modules.add(module);
+            world.getModules().add(module);
+        }
+
+        World saved = worldRepository.save(world);
+        List<WorldModule> persistedModules = worldModuleRepository.findByWorldId(saved.getId());
+        return new WorldAggregate(saved, persistedModules);
+    }
+
+    @Transactional(readOnly = true)
+    public WorldAggregate getWorld(Long worldId, Long userId) {
+        World world = loadWorld(worldId, userId);
+        List<WorldModule> modules = worldModuleRepository.findByWorldId(worldId);
+        return new WorldAggregate(world, modules);
+    }
+
+    @Transactional(readOnly = true)
+    public List<WorldAggregate> listWorlds(Long userId, WorldStatus statusFilter) {
+        List<World> worlds;
+        if (statusFilter == null) {
+            worlds = worldRepository.findAllByUserIdOrderByUpdatedAtDesc(userId);
+        } else {
+            worlds = worldRepository.findAllByUserIdAndStatusOrderByUpdatedAtDesc(userId, statusFilter);
+        }
+        if (worlds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<Long> worldIds = worlds.stream().map(World::getId).toList();
+        Map<Long, List<WorldModule>> moduleMap = worldModuleRepository.findByWorldIdIn(worldIds)
+                .stream()
+                .collect(Collectors.groupingBy(module -> module.getWorld().getId()));
+        return worlds.stream()
+                .map(world -> new WorldAggregate(world, moduleMap.getOrDefault(world.getId(), List.of())))
+                .collect(Collectors.toList());
+    }
+
+    public WorldAggregate updateWorld(Long worldId, Long userId, WorldUpsertRequest request) {
+        validateBasicInfo(request);
+        World world = loadWorld(worldId, userId);
+        if (world.getStatus() == WorldStatus.GENERATING) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "世界正在生成中，无法修改");
+        }
+        boolean changed = applyBasicInfo(world, request);
+        if (changed) {
+            if (world.getStatus() == WorldStatus.ACTIVE) {
+                world.setStatus(WorldStatus.DRAFT);
+            }
+            world.setLastEditedBy(userId);
+            world.setLastEditedAt(LocalDateTime.now());
+        }
+        World saved = worldRepository.save(world);
+        List<WorldModule> modules = worldModuleRepository.findByWorldId(worldId);
+        return new WorldAggregate(saved, modules);
+    }
+
+    public void deleteWorld(Long worldId, Long userId) {
+        World world = loadWorld(worldId, userId);
+        if (world.getStatus() != WorldStatus.DRAFT || (world.getVersion() != null && world.getVersion() > 0)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "仅允许删除未发布的草稿世界");
+        }
+        worldRepository.delete(world);
+    }
+
+    private World loadWorld(Long worldId, Long userId) {
+        return worldRepository.findByIdAndUserId(worldId, userId)
+                .orElseThrow(() -> new ResourceNotFoundException("世界不存在或无权访问"));
+    }
+
+    private void validateBasicInfo(WorldUpsertRequest request) {
+        String name = safeTrim(request.getName());
+        if (name == null || name.length() < 1 || name.length() > 80) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "世界名称需 1-80 字符");
+        }
+        String tagline = safeTrim(request.getTagline());
+        if (tagline == null || tagline.length() < 20 || tagline.length() > 180) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "一句话概述需 20-180 字");
+        }
+        String creativeIntent = safeTrim(request.getCreativeIntent());
+        if (creativeIntent == null || creativeIntent.length() < 150) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "创作意图需至少 150 字");
+        }
+        String notes = safeTrim(request.getNotes());
+        if (notes != null && notes.length() > 300) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "开发者备注最长 300 字");
+        }
+        List<String> themes = sanitizeThemes(request.getThemes());
+        if (themes.size() < MIN_THEMES) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "至少提供 1 个主题标签");
+        }
+    }
+
+    private boolean applyBasicInfo(World world, WorldUpsertRequest request) {
+        boolean changed = false;
+        String name = safeTrim(request.getName());
+        if (!Objects.equals(world.getName(), name)) {
+            world.setName(name);
+            changed = true;
+        }
+        String tagline = safeTrim(request.getTagline());
+        if (!Objects.equals(world.getTagline(), tagline)) {
+            world.setTagline(tagline);
+            changed = true;
+        }
+        String creativeIntent = safeTrim(request.getCreativeIntent());
+        if (!Objects.equals(world.getCreativeIntent(), creativeIntent)) {
+            world.setCreativeIntent(creativeIntent);
+            changed = true;
+        }
+        String notes = safeTrim(request.getNotes());
+        if (!Objects.equals(world.getNotes(), notes)) {
+            world.setNotes(notes);
+            changed = true;
+        }
+        List<String> themes = sanitizeThemes(request.getThemes());
+        if (!Objects.equals(world.getThemes(), themes)) {
+            world.setThemes(new ArrayList<>(themes));
+            changed = true;
+        }
+        return changed;
+    }
+
+    private List<String> sanitizeThemes(List<String> rawThemes) {
+        if (rawThemes == null) {
+            return List.of();
+        }
+        List<String> cleaned = new ArrayList<>();
+        for (String theme : rawThemes) {
+            String value = safeTrim(theme);
+            if (value == null || value.isEmpty()) {
+                continue;
+            }
+            if (value.length() > MAX_THEME_LENGTH) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "主题标签长度需在 1-" + MAX_THEME_LENGTH + " 字之间");
+            }
+            cleaned.add(value);
+        }
+        if (cleaned.size() > MAX_THEMES) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "主题标签最多 5 个");
+        }
+        // 去重但保留顺序
+        List<String> distinct = new ArrayList<>();
+        Set<String> seen = new java.util.LinkedHashSet<>();
+        for (String item : cleaned) {
+            if (seen.add(item)) {
+                distinct.add(item);
+            }
+        }
+        return distinct;
+    }
+
+    private String safeTrim(String value) {
+        return value == null ? null : value.trim();
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/worldbuilding/definition/WorldModuleDefinition.java
+++ b/backend/src/main/java/com/example/ainovel/worldbuilding/definition/WorldModuleDefinition.java
@@ -1,0 +1,19 @@
+package com.example.ainovel.worldbuilding.definition;
+
+import java.util.List;
+
+public record WorldModuleDefinition(
+        String key,
+        String label,
+        List<FieldDefinition> fields,
+        int order
+) {
+    public record FieldDefinition(
+            String key,
+            String label,
+            boolean required,
+            int minLength,
+            int maxLength
+    ) {
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/worldbuilding/definition/WorldModuleDefinitionRegistry.java
+++ b/backend/src/main/java/com/example/ainovel/worldbuilding/definition/WorldModuleDefinitionRegistry.java
@@ -1,0 +1,79 @@
+package com.example.ainovel.worldbuilding.definition;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class WorldModuleDefinitionRegistry {
+
+    private final Map<String, WorldModuleDefinition> definitionMap = new ConcurrentHashMap<>();
+    private final List<WorldModuleDefinition> orderedDefinitions;
+
+    public WorldModuleDefinitionRegistry(@Value("classpath:worldbuilding/modules.yml") Resource resource) {
+        Objects.requireNonNull(resource, "Module definition resource must not be null");
+        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+        objectMapper.findAndRegisterModules();
+        try (InputStream inputStream = resource.getInputStream()) {
+            WorldModuleDefinitionsConfig config = objectMapper.readValue(inputStream, WorldModuleDefinitionsConfig.class);
+            if (config == null || config.modules() == null || config.modules().isEmpty()) {
+                throw new IllegalStateException("World module definitions must not be empty");
+            }
+            orderedDefinitions = config.modules().stream()
+                    .sorted(Comparator.comparingInt(WorldModuleDefinition::order))
+                    .toList();
+            for (WorldModuleDefinition definition : orderedDefinitions) {
+                definitionMap.put(definition.key(), definition);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load world module definitions", e);
+        }
+    }
+
+    public List<WorldModuleDefinition> getAll() {
+        return orderedDefinitions;
+    }
+
+    public Optional<WorldModuleDefinition> find(String key) {
+        if (key == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(definitionMap.get(key));
+    }
+
+    public WorldModuleDefinition requireModule(String key) {
+        return find(key).orElseThrow(() -> new IllegalArgumentException("Unknown module key: " + key));
+    }
+
+    public WorldModuleDefinition.FieldDefinition requireField(String moduleKey, String fieldKey) {
+        WorldModuleDefinition moduleDefinition = requireModule(moduleKey);
+        return moduleDefinition.fields().stream()
+                .filter(field -> field.key().equals(fieldKey))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Unknown field key: " + fieldKey + " for module " + moduleKey));
+    }
+
+    public String resolveLabel(String moduleKey) {
+        return find(moduleKey).map(WorldModuleDefinition::label)
+                .orElse(moduleKey);
+    }
+
+    public Optional<String> resolveFieldLabel(String moduleKey, String fieldKey) {
+        return find(moduleKey).flatMap(def -> def.fields().stream()
+                .filter(field -> field.key().equals(fieldKey))
+                .map(WorldModuleDefinition.FieldDefinition::label)
+                .findFirst());
+    }
+}

--- a/backend/src/main/java/com/example/ainovel/worldbuilding/definition/WorldModuleDefinitionsConfig.java
+++ b/backend/src/main/java/com/example/ainovel/worldbuilding/definition/WorldModuleDefinitionsConfig.java
@@ -1,0 +1,6 @@
+package com.example.ainovel.worldbuilding.definition;
+
+import java.util.List;
+
+public record WorldModuleDefinitionsConfig(List<WorldModuleDefinition> modules) {
+}

--- a/backend/src/main/resources/worldbuilding/modules.yml
+++ b/backend/src/main/resources/worldbuilding/modules.yml
@@ -1,0 +1,204 @@
+modules:
+  - key: cosmos
+    label: "宇宙观与法则"
+    order: 1
+    fields:
+      - key: cosmos_structure
+        label: "宇宙结构与尺度"
+        required: true
+        minLength: 200
+        maxLength: 600
+      - key: space_time
+        label: "时间与空间规则"
+        required: true
+        minLength: 180
+        maxLength: 500
+      - key: energy_system
+        label: "能量/魔法来源与运作"
+        required: true
+        minLength: 220
+        maxLength: 600
+      - key: technology_magic_balance
+        label: "科技与超自然的关系"
+        required: true
+        minLength: 180
+        maxLength: 450
+      - key: constraints
+        label: "法则限制与禁忌"
+        required: true
+        minLength: 150
+        maxLength: 400
+  - key: geography
+    label: "地理与生态"
+    order: 2
+    fields:
+      - key: world_map_overview
+        label: "世界格局概览"
+        required: true
+        minLength: 200
+        maxLength: 600
+      - key: signature_regions
+        label: "代表性区域与地标"
+        required: true
+        minLength: 150
+        maxLength: 800
+      - key: climate_cycles
+        label: "气候与季节循环"
+        required: true
+        minLength: 180
+        maxLength: 500
+      - key: sapient_species
+        label: "智慧种族与分布"
+        required: true
+        minLength: 220
+        maxLength: 600
+      - key: ecosystems_resources
+        label: "生态系统与关键资源"
+        required: true
+        minLength: 220
+        maxLength: 600
+  - key: society
+    label: "社会与政治"
+    order: 3
+    fields:
+      - key: political_landscape
+        label: "政体与势力分布"
+        required: true
+        minLength: 200
+        maxLength: 600
+      - key: law_order
+        label: "法律体系与社会秩序"
+        required: true
+        minLength: 180
+        maxLength: 500
+      - key: social_structure
+        label: "社会阶层与民生结构"
+        required: true
+        minLength: 200
+        maxLength: 550
+      - key: military_conflict
+        label: "军事力量与冲突态势"
+        required: true
+        minLength: 200
+        maxLength: 500
+      - key: governance_dynamics
+        label: "权力运作与治理模式"
+        required: true
+        minLength: 200
+        maxLength: 500
+  - key: history
+    label: "历史与传说"
+    order: 4
+    fields:
+      - key: creation_myth
+        label: "创世神话与起源"
+        required: true
+        minLength: 180
+        maxLength: 500
+      - key: timeline_epochs
+        label: "纪元与年代划分"
+        required: true
+        minLength: 0
+        maxLength: 0
+      - key: turning_points
+        label: "关键历史事件"
+        required: true
+        minLength: 120
+        maxLength: 800
+      - key: legendary_figures
+        label: "传奇人物与传承"
+        required: true
+        minLength: 180
+        maxLength: 500
+      - key: prophecies
+        label: "预言、禁忌与未解之谜"
+        required: true
+        minLength: 150
+        maxLength: 450
+  - key: culture
+    label: "文化与日常"
+    order: 5
+    fields:
+      - key: religion_faith
+        label: "宗教体系与信仰实践"
+        required: true
+        minLength: 200
+        maxLength: 500
+      - key: language_communication
+        label: "语言与交流"
+        required: true
+        minLength: 180
+        maxLength: 400
+      - key: arts_entertainment
+        label: "艺术、娱乐与媒体"
+        required: true
+        minLength: 180
+        maxLength: 450
+      - key: customs_rituals
+        label: "社会习俗与仪式"
+        required: true
+        minLength: 180
+        maxLength: 450
+      - key: values_morality
+        label: "价值观与伦理争议"
+        required: true
+        minLength: 200
+        maxLength: 500
+  - key: economy
+    label: "经济与科技"
+    order: 6
+    fields:
+      - key: economic_system
+        label: "经济体系与货币"
+        required: true
+        minLength: 200
+        maxLength: 500
+      - key: industry_trade
+        label: "产业与贸易网络"
+        required: true
+        minLength: 200
+        maxLength: 500
+      - key: technology_level
+        label: "科技/魔法应用水平"
+        required: true
+        minLength: 200
+        maxLength: 500
+      - key: infrastructure
+        label: "交通、通讯与基础设施"
+        required: true
+        minLength: 200
+        maxLength: 450
+      - key: daily_life_tech
+        label: "日常生活技术与民生"
+        required: true
+        minLength: 180
+        maxLength: 400
+  - key: factions
+    label: "势力与剧情钩子"
+    order: 7
+    fields:
+      - key: faction_overview
+        label: "主导势力与组织"
+        required: true
+        minLength: 200
+        maxLength: 500
+      - key: species_relations
+        label: "种族关系与联盟"
+        required: true
+        minLength: 200
+        maxLength: 500
+      - key: current_conflicts
+        label: "当前冲突与危机"
+        required: true
+        minLength: 180
+        maxLength: 450
+      - key: key_locations
+        label: "关键地点与剧情场景"
+        required: true
+        minLength: 180
+        maxLength: 450
+      - key: story_hooks
+        label: "故事钩子与潜在剧情线"
+        required: true
+        minLength: 120
+        maxLength: 800


### PR DESCRIPTION
## Summary
- add world and world module entities with JSON converters plus schema updates for persistence
- create services, repositories, DTOs and controller endpoints covering world CRUD, module saves and publication preparation flows
- load step-one module metadata from a YAML-backed definition registry for validation and consistent labels

## Testing
- mvn test *(fails: Maven cannot reach remote repository in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d00f4f7fcc83309be7b1c21678e093