### PR TITLE
Polish world builder refine flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import HomePage from './components/HomePage';
 import ProtectedRoute from './components/ProtectedRoute';
 import Settings from './components/Settings';
 import PromptHelpPage from './components/PromptHelpPage';
+import WorldBuilderPage from './pages/WorldBuilder/WorldBuilderPage';
 import { AuthProvider } from './contexts/AuthContext';
 
 function App() {
@@ -48,6 +49,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <PromptHelpPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/worlds"
+            element={
+              <ProtectedRoute>
+                <WorldBuilderPage />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -22,9 +22,14 @@ const HomePage: React.FC = () => {
           </>
         )}
         {isAuthenticated && (
-          <Link to="/workbench">
-            <Button type="primary" size="large">进入工作台</Button>
-          </Link>
+          <>
+            <Link to="/workbench">
+              <Button type="primary" size="large">进入工作台</Button>
+            </Link>
+            <Link to="/worlds">
+              <Button size="large">世界构建</Button>
+            </Link>
+          </>
         )}
       </nav>
     </div>

--- a/frontend/src/components/WorkbenchHeader.tsx
+++ b/frontend/src/components/WorkbenchHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Layout, Dropdown, Typography, Space, Button } from 'antd';
+import { Link } from 'react-router-dom';
 import { UserOutlined, SettingOutlined, LogoutOutlined } from '@ant-design/icons';
 
 const { Header } = Layout;
@@ -45,6 +46,9 @@ const WorkbenchHeader: React.FC<WorkbenchHeaderProps> = ({ username, onOpenSetti
       <Space align="center">
         <img src="/vite.svg" alt="AI 小说家" style={{ width: 28, height: 28 }} />
         <Title level={3} style={{ margin: 0 }}>AI 小说家工作台</Title>
+        <Link to="/worlds">
+          <Button type="link">世界构建</Button>
+        </Link>
       </Space>
 
       <Dropdown menu={{ items }} trigger={['click']}>

--- a/frontend/src/pages/WorldBuilder/WorldBuilderPage.tsx
+++ b/frontend/src/pages/WorldBuilder/WorldBuilderPage.tsx
@@ -1,0 +1,700 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, Empty, Layout, Modal, Space, Spin, Typography, message } from 'antd';
+import { ExclamationCircleOutlined } from '@ant-design/icons';
+import WorldSelectorPanel from './components/WorldSelectorPanel';
+import MetadataForm from './components/MetadataForm';
+import type { MetadataFormValue } from './components/MetadataForm';
+import ModuleTabs from './components/ModuleTabs';
+import StickyFooterBar from './components/StickyFooterBar';
+import type { SaveState } from './components/StickyFooterBar';
+import GenerationProgressModal from './components/GenerationProgressModal';
+import RefineModal from '../../components/modals/RefineModal';
+import {
+    createWorld,
+    deleteWorld,
+    fetchWorldBuildingDefinitions,
+    fetchWorldDetail,
+    fetchWorldGenerationStatus,
+    fetchWorlds,
+    generateWorldModule,
+    previewWorldPublish,
+    publishWorld,
+    refineWorldField,
+    retryWorldGeneration,
+    updateWorld,
+    updateWorldModules,
+    type WorldUpsertPayload,
+} from '../../services/api';
+import type {
+    WorldBuildingDefinitionsResponse,
+    WorldDetail,
+    WorldGenerationStatus,
+    WorldModule,
+    WorldModuleDefinition,
+    WorldSummary,
+} from '../../types';
+
+const { Content } = Layout;
+const { Title, Paragraph } = Typography;
+
+const AUTO_SAVE_DELAY = 2000;
+
+const cloneWorldDetail = (detail: WorldDetail): WorldDetail => {
+    return JSON.parse(JSON.stringify(detail)) as WorldDetail;
+};
+
+const mergeModules = (current: WorldModule[], updated: WorldModule[]): WorldModule[] => {
+    if (!updated.length) return current;
+    const updatedMap = new Map(updated.map(module => [module.key, module]));
+    const merged = current.map(module => updatedMap.get(module.key) ?? module);
+    updated.forEach(module => {
+        if (!current.find(item => item.key === module.key)) {
+            merged.push(module);
+        }
+    });
+    return merged;
+};
+
+const initialCreativeIntent = '（占位文案）请在此处写下你的创作意图、灵感来源、预期主题以及需要遵守的世界观边界。建议至少 150 字，说明故事想聚焦的冲突、角色成长方向和需要避免的情节。该文本仅为占位，请尽快替换为真实内容，以帮助 AI 在生成时保持一致性和合理性。';
+
+const buildBasicInfoPayload = (detail: WorldDetail): WorldUpsertPayload => ({
+    name: detail.world.name,
+    tagline: detail.world.tagline,
+    themes: detail.world.themes ?? [],
+    creativeIntent: detail.world.creativeIntent,
+    notes: detail.world.notes ?? '',
+});
+
+const WorldBuilderPage: React.FC = () => {
+    const [definitions, setDefinitions] = useState<WorldBuildingDefinitionsResponse | null>(null);
+    const [loadingDefinitions, setLoadingDefinitions] = useState(true);
+    const [worlds, setWorlds] = useState<WorldSummary[]>([]);
+    const [loadingWorlds, setLoadingWorlds] = useState(false);
+    const [selectedWorldId, setSelectedWorldId] = useState<number | null>(null);
+    const [worldDetail, setWorldDetail] = useState<WorldDetail | null>(null);
+    const [baselineDetail, setBaselineDetail] = useState<WorldDetail | null>(null);
+    const [loadingDetail, setLoadingDetail] = useState(false);
+    const [dirtyBasicInfo, setDirtyBasicInfo] = useState<Partial<MetadataFormValue>>({});
+    const [dirtyModules, setDirtyModules] = useState<Record<string, Record<string, string>>>({});
+    const [saveState, setSaveState] = useState<SaveState>('saved');
+    const autoSaveTimer = useRef<number | undefined>(undefined);
+    const [creating, setCreating] = useState(false);
+    const [moduleLoadingKeys, setModuleLoadingKeys] = useState<Set<string>>(new Set());
+    const [publishing, setPublishing] = useState(false);
+    const [progressVisible, setProgressVisible] = useState(false);
+    const [progressStatus, setProgressStatus] = useState<WorldGenerationStatus | null>(null);
+    const [progressLoading, setProgressLoading] = useState(false);
+    const progressTimerRef = useRef<number | undefined>(undefined);
+    const pollingWorldRef = useRef<number | null>(null);
+    const [refineState, setRefineState] = useState<{
+        moduleKey: string;
+        fieldKey: string;
+        moduleLabel: string;
+        fieldLabel: string;
+        text: string;
+    } | null>(null);
+    const hasDirtyBasicInfo = useMemo(() => Object.keys(dirtyBasicInfo).length > 0, [dirtyBasicInfo]);
+    const hasDirtyModules = useMemo(() => Object.keys(dirtyModules).length > 0, [dirtyModules]);
+    const hasUnsavedChanges = hasDirtyBasicInfo || hasDirtyModules;
+    const isEditingDisabled = worldDetail?.world.status === 'GENERATING';
+
+    const draftWorlds = useMemo(() => worlds.filter(world => world.status === 'DRAFT'), [worlds]);
+    const publishedWorlds = useMemo(() => worlds.filter(world => world.status !== 'DRAFT'), [worlds]);
+    const selectedWorldSummary = useMemo(
+        () => (selectedWorldId ? worlds.find(world => world.id === selectedWorldId) : undefined),
+        [selectedWorldId, worlds]
+    );
+
+    const clearAutoSaveTimer = useCallback(() => {
+        if (autoSaveTimer.current) {
+            window.clearTimeout(autoSaveTimer.current);
+            autoSaveTimer.current = undefined;
+        }
+    }, []);
+
+    const stopPolling = useCallback(() => {
+        if (progressTimerRef.current) {
+            window.clearInterval(progressTimerRef.current);
+            progressTimerRef.current = undefined;
+        }
+        pollingWorldRef.current = null;
+        setProgressLoading(false);
+    }, []);
+
+    const loadWorldSummaries = useCallback(async () => {
+        setLoadingWorlds(true);
+        try {
+            const data = await fetchWorlds();
+            setWorlds(data);
+            if (selectedWorldId != null && !data.some(world => world.id === selectedWorldId)) {
+                setSelectedWorldId(data.length ? data[0].id : null);
+            }
+        } catch (err) {
+            message.error(err instanceof Error ? err.message : '加载世界列表失败');
+        } finally {
+            setLoadingWorlds(false);
+        }
+    }, [selectedWorldId]);
+
+    const startPolling = useCallback(async (worldId: number) => {
+        if (pollingWorldRef.current === worldId) {
+            return;
+        }
+        stopPolling();
+        pollingWorldRef.current = worldId;
+        setProgressVisible(true);
+        setProgressLoading(true);
+
+        const fetchStatus = async () => {
+            try {
+                const status = await fetchWorldGenerationStatus(worldId);
+                if (pollingWorldRef.current !== worldId) {
+                    return;
+                }
+                setProgressStatus(status);
+                if (status.status !== 'GENERATING') {
+                    stopPolling();
+                    setProgressVisible(false);
+                    message.success('世界完整信息生成完成');
+                    await loadWorldSummaries();
+                    try {
+                        const detail = await fetchWorldDetail(worldId);
+                        setWorldDetail(detail);
+                        setBaselineDetail(cloneWorldDetail(detail));
+                        setDirtyBasicInfo({});
+                        setDirtyModules({});
+                        setSaveState('saved');
+                    } catch (err) {
+                        message.error(err instanceof Error ? err.message : '刷新世界详情失败');
+                    }
+                }
+            } catch (err) {
+                if (pollingWorldRef.current === worldId) {
+                    message.error(err instanceof Error ? err.message : '获取生成进度失败');
+                }
+            } finally {
+                setProgressLoading(false);
+            }
+        };
+
+        await fetchStatus();
+        progressTimerRef.current = window.setInterval(fetchStatus, 3000);
+    }, [loadWorldSummaries, stopPolling]);
+
+    const loadWorldDetail = useCallback(async (worldId: number) => {
+        setLoadingDetail(true);
+        try {
+            const detail = await fetchWorldDetail(worldId);
+            setWorldDetail(detail);
+            setBaselineDetail(cloneWorldDetail(detail));
+            setDirtyBasicInfo({});
+            setDirtyModules({});
+            setSaveState('saved');
+            if (detail.world.status === 'GENERATING') {
+                startPolling(worldId);
+            } else if (pollingWorldRef.current === worldId) {
+                stopPolling();
+                setProgressVisible(false);
+                setProgressStatus(null);
+            }
+        } catch (err) {
+            message.error(err instanceof Error ? err.message : '加载世界详情失败');
+        } finally {
+            setLoadingDetail(false);
+        }
+    }, [startPolling, stopPolling]);
+
+    useEffect(() => {
+        const fetchDefinitions = async () => {
+            setLoadingDefinitions(true);
+            try {
+                const data = await fetchWorldBuildingDefinitions();
+                setDefinitions(data);
+            } catch (err) {
+                message.error(err instanceof Error ? err.message : '加载模块定义失败');
+            } finally {
+                setLoadingDefinitions(false);
+            }
+        };
+        fetchDefinitions();
+    }, []);
+
+    useEffect(() => {
+        loadWorldSummaries();
+    }, [loadWorldSummaries]);
+
+    useEffect(() => {
+        if (selectedWorldId == null) {
+            setWorldDetail(null);
+            setBaselineDetail(null);
+            return;
+        }
+        loadWorldDetail(selectedWorldId);
+    }, [selectedWorldId, loadWorldDetail]);
+
+    useEffect(() => {
+        return () => {
+            clearAutoSaveTimer();
+            stopPolling();
+        };
+    }, [clearAutoSaveTimer, stopPolling]);
+
+    useEffect(() => {
+        const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+            if (hasUnsavedChanges || saveState === 'saving') {
+                event.preventDefault();
+                event.returnValue = '';
+            }
+        };
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+    }, [hasUnsavedChanges, saveState]);
+
+    const saveDraft = useCallback(async ({ silent = false }: { silent?: boolean } = {}): Promise<boolean> => {
+        if (!worldDetail || !baselineDetail) {
+            return true;
+        }
+        if (!hasUnsavedChanges) {
+            return true;
+        }
+        clearAutoSaveTimer();
+        setSaveState('saving');
+        try {
+            let updatedDetail = worldDetail;
+            if (hasDirtyBasicInfo) {
+                const payload = buildBasicInfoPayload(updatedDetail);
+                const response = await updateWorld(updatedDetail.world.id!, payload);
+                updatedDetail = { ...updatedDetail, world: response.world };
+                setWorldDetail(prev => (prev ? { ...prev, world: response.world } : response));
+                setBaselineDetail(prev => (prev ? { ...prev, world: response.world } : cloneWorldDetail(response)));
+            }
+            if (hasDirtyModules) {
+                const modulesPayload = Object.entries(dirtyModules).map(([key, fields]) => ({ key, fields }));
+                if (modulesPayload.length > 0) {
+                    const modules = await updateWorldModules(updatedDetail.world.id!, modulesPayload);
+                    const merged = mergeModules(updatedDetail.modules, modules);
+                    updatedDetail = { ...updatedDetail, modules: merged };
+                    setWorldDetail(updatedDetail);
+                    setBaselineDetail(prev => (prev ? { ...prev, modules: merged } : cloneWorldDetail(updatedDetail)));
+                }
+            }
+            setDirtyBasicInfo({});
+            setDirtyModules({});
+            setSaveState('saved');
+            if (!silent) {
+                message.success('草稿已保存');
+            }
+            await loadWorldSummaries();
+            return true;
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : '保存失败';
+            if (!silent) {
+                message.error(msg);
+            }
+            setSaveState('error');
+            return false;
+        }
+    }, [baselineDetail, dirtyModules, hasDirtyBasicInfo, hasDirtyModules, hasUnsavedChanges, loadWorldSummaries, worldDetail, clearAutoSaveTimer]);
+
+    const scheduleAutoSave = useCallback(() => {
+        clearAutoSaveTimer();
+        autoSaveTimer.current = window.setTimeout(() => {
+            void saveDraft({ silent: true });
+        }, AUTO_SAVE_DELAY);
+    }, [clearAutoSaveTimer, saveDraft]);
+
+    const handleMetadataChange = useCallback(<K extends keyof MetadataFormValue>(field: K, value: MetadataFormValue[K]) => {
+        if (!worldDetail || !baselineDetail) return;
+        setWorldDetail(prev => (prev ? { ...prev, world: { ...prev.world, [field]: value } } : prev));
+        setDirtyBasicInfo(prev => {
+            const next = { ...prev };
+            const baselineValue = baselineDetail.world[field];
+            const isEqual = Array.isArray(value)
+                ? JSON.stringify(value) === JSON.stringify(baselineValue ?? [])
+                : (baselineValue ?? '') === value;
+            if (isEqual) {
+                delete (next as Record<string, unknown>)[field as string];
+            } else {
+                (next as Record<string, unknown>)[field as string] = value as unknown as string;
+            }
+            return next;
+        });
+        setSaveState('pending');
+        scheduleAutoSave();
+    }, [baselineDetail, scheduleAutoSave, worldDetail]);
+
+    const handleFieldChange = useCallback((moduleKey: string, fieldKey: string, value: string) => {
+        if (!worldDetail || !baselineDetail) return;
+        setWorldDetail(prev => {
+            if (!prev) return prev;
+            const modules = prev.modules.map(module =>
+                module.key === moduleKey
+                    ? { ...module, fields: { ...module.fields, [fieldKey]: value } }
+                    : module
+            );
+            return { ...prev, modules };
+        });
+        setDirtyModules(prev => {
+            const next = { ...prev };
+            const baselineModule = baselineDetail.modules.find(module => module.key === moduleKey);
+            const baselineValue = baselineModule?.fields?.[fieldKey] ?? '';
+            if (value === baselineValue) {
+                if (next[moduleKey]) {
+                    const fields = { ...next[moduleKey] };
+                    delete fields[fieldKey];
+                    if (Object.keys(fields).length === 0) {
+                        delete next[moduleKey];
+                    } else {
+                        next[moduleKey] = fields;
+                    }
+                }
+            } else {
+                next[moduleKey] = { ...(next[moduleKey] ?? {}), [fieldKey]: value };
+            }
+            return next;
+        });
+        setSaveState('pending');
+        scheduleAutoSave();
+    }, [baselineDetail, scheduleAutoSave, worldDetail]);
+    const handleOpenRefine = useCallback((moduleKey: string, fieldKey: string, fieldLabel: string, originalText: string) => {
+        const moduleDefinition = definitions?.modules.find(def => def.key === moduleKey);
+        setRefineState({
+            moduleKey,
+            fieldKey,
+            fieldLabel,
+            moduleLabel: moduleDefinition?.label ?? moduleKey,
+            text: originalText,
+        });
+    }, [definitions?.modules]);
+
+    const handleApplyRefine = useCallback((newText: string) => {
+        if (!refineState) return;
+        handleFieldChange(refineState.moduleKey, refineState.fieldKey, newText);
+        setRefineState(null);
+    }, [handleFieldChange, refineState]);
+
+    const handleRefineRequest = useCallback(async (text: string, instruction: string) => {
+        if (!worldDetail || !refineState) return text;
+        try {
+            const response = await refineWorldField(worldDetail.world.id!, refineState.moduleKey, refineState.fieldKey, {
+                text,
+                instruction,
+            });
+            if (!response || typeof response.result !== 'string') {
+                throw new Error('AI 返回结果为空，请稍后重试');
+            }
+            return response.result;
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : '字段优化失败，请稍后重试';
+            message.error(errorMessage);
+            throw (error instanceof Error ? error : new Error(errorMessage));
+        }
+    }, [refineState, worldDetail]);
+
+    const handleGenerateModule = useCallback(async (moduleKey: string) => {
+        if (!worldDetail) return;
+        setModuleLoadingKeys(prev => new Set(prev).add(moduleKey));
+        try {
+            const module = await generateWorldModule(worldDetail.world.id!, moduleKey);
+            setWorldDetail(prev => (prev ? { ...prev, modules: mergeModules(prev.modules, [module]) } : prev));
+            setBaselineDetail(prev => {
+                const base = prev ?? (worldDetail ? cloneWorldDetail(worldDetail) : null);
+                return base ? { ...base, modules: mergeModules(base.modules, [module]) } : base;
+            });
+            setDirtyModules(prev => {
+                if (!prev[moduleKey]) return prev;
+                const next = { ...prev };
+                delete next[moduleKey];
+                return next;
+            });
+            message.success(`${module.label} 模块已生成`);
+        } catch (err) {
+            message.error(err instanceof Error ? err.message : '模块生成失败');
+        } finally {
+            setModuleLoadingKeys(prev => {
+                const next = new Set(prev);
+                next.delete(moduleKey);
+                return next;
+            });
+        }
+    }, [worldDetail]);
+
+    const handleViewFullContent = useCallback((_: string, label: string, content: string) => {
+        if (!content) {
+            message.info('该模块尚未生成完整信息');
+            return;
+        }
+        Modal.info({
+            title: `${label} · 完整信息`,
+            width: 760,
+            content: (
+                <Paragraph style={{ whiteSpace: 'pre-wrap' }}>
+                    {content}
+                </Paragraph>
+            ),
+        });
+    }, []);
+    const handleCreateWorld = useCallback(async () => {
+        setCreating(true);
+        try {
+            const detail = await createWorld({
+                name: '未命名世界',
+                tagline: '请填写一句话世界概述，突出设定亮点与核心冲突。',
+                themes: ['待补充主题'],
+                creativeIntent: initialCreativeIntent,
+                notes: '',
+            });
+            message.success('已创建新世界，请完善基础信息');
+            setWorldDetail(detail);
+            setBaselineDetail(cloneWorldDetail(detail));
+            setDirtyBasicInfo({});
+            setDirtyModules({});
+            setSaveState('saved');
+            await loadWorldSummaries();
+            setSelectedWorldId(detail.world.id ?? null);
+        } catch (err) {
+            message.error(err instanceof Error ? err.message : '新建世界失败');
+        } finally {
+            setCreating(false);
+        }
+    }, [loadWorldSummaries]);
+
+    const handleSelectWorld = useCallback((worldId: number) => {
+        if (worldId === selectedWorldId) return;
+        const proceed = () => setSelectedWorldId(worldId);
+        if (hasUnsavedChanges) {
+            Modal.confirm({
+                title: '切换世界',
+                icon: <ExclamationCircleOutlined />,
+                content: '当前世界存在未保存的修改，切换前需要先保存。',
+                okText: '保存并切换',
+                cancelText: '取消',
+                onOk: async () => {
+                    const success = await saveDraft({ silent: false });
+                    if (success) {
+                        proceed();
+                    }
+                },
+            });
+        } else {
+            proceed();
+        }
+    }, [hasUnsavedChanges, saveDraft, selectedWorldId]);
+
+    const handleRenameDraft = useCallback(async (worldId: number, newName: string) => {
+        try {
+            const detail = worldId === worldDetail?.world.id ? worldDetail : await fetchWorldDetail(worldId);
+            if (!detail) return;
+            const payload = buildBasicInfoPayload(detail);
+            payload.name = newName;
+            const response = await updateWorld(worldId, payload);
+            if (worldId === worldDetail?.world.id) {
+                setWorldDetail(prev => (prev ? { ...prev, world: response.world } : response));
+                setBaselineDetail(prev => (prev ? { ...prev, world: response.world } : cloneWorldDetail(response)));
+                setDirtyBasicInfo(prev => {
+                    const next = { ...prev };
+                    delete next.name;
+                    return next;
+                });
+            }
+            await loadWorldSummaries();
+            message.success('重命名成功');
+        } catch (err) {
+            message.error(err instanceof Error ? err.message : '重命名失败');
+        }
+    }, [loadWorldSummaries, worldDetail]);
+
+    const handleDeleteDraft = useCallback(async (worldId: number) => {
+        try {
+            await deleteWorld(worldId);
+            message.success('草稿已删除');
+            await loadWorldSummaries();
+            if (worldId === selectedWorldId) {
+                setSelectedWorldId(null);
+                setWorldDetail(null);
+                setBaselineDetail(null);
+            }
+        } catch (err) {
+            message.error(err instanceof Error ? err.message : '删除失败');
+        }
+    }, [loadWorldSummaries, selectedWorldId]);
+    const handlePublish = useCallback(async () => {
+        if (!worldDetail) return;
+        if (worldDetail.world.status === 'GENERATING') {
+            message.info('世界正在生成中，请稍后再试');
+            return;
+        }
+        const saved = await saveDraft({ silent: false });
+        if (!saved) return;
+        setPublishing(true);
+        try {
+            const preview = await previewWorldPublish(worldDetail.world.id!);
+            if (!preview.ready) {
+                Modal.warning({
+                    title: '仍有未完成的字段',
+                    content: preview.missingFields.length ? (
+                        <div>
+                            {preview.missingFields.map(field => (
+                                <div key={`${field.moduleKey}-${field.fieldKey}`}>
+                                    {field.moduleLabel} · {field.fieldLabel}
+                                </div>
+                            ))}
+                        </div>
+                    ) : '请检查各模块状态，确保内容完整。',
+                });
+                return;
+            }
+            const response = await publishWorld(worldDetail.world.id!);
+            message.success('已提交生成任务，开始生成完整信息');
+            const toGenerateKeys = new Set(response.modulesToGenerate.map(module => module.key));
+            setWorldDetail(prev => prev ? {
+                ...prev,
+                world: { ...prev.world, status: 'GENERATING' },
+                modules: prev.modules.map(module =>
+                    toGenerateKeys.has(module.key)
+                        ? { ...module, status: 'AWAITING_GENERATION' }
+                        : module
+                ),
+            } : prev);
+            setBaselineDetail(prev => prev ? {
+                ...prev,
+                world: { ...prev.world, status: 'GENERATING' },
+                modules: prev.modules.map(module =>
+                    toGenerateKeys.has(module.key)
+                        ? { ...module, status: 'AWAITING_GENERATION' }
+                        : module
+                ),
+            } : prev);
+            await loadWorldSummaries();
+            await startPolling(worldDetail.world.id!);
+        } catch (err) {
+            message.error(err instanceof Error ? err.message : '正式创建失败');
+        } finally {
+            setPublishing(false);
+        }
+    }, [loadWorldSummaries, saveDraft, startPolling, worldDetail]);
+
+    const handleRetryModule = useCallback(async (moduleKey: string) => {
+        if (!worldDetail) return;
+        try {
+            await retryWorldGeneration(worldDetail.world.id!, moduleKey);
+            message.success('已重新排队');
+            if (pollingWorldRef.current === worldDetail.world.id) {
+                const status = await fetchWorldGenerationStatus(worldDetail.world.id!);
+                setProgressStatus(status);
+            } else {
+                await startPolling(worldDetail.world.id!);
+            }
+        } catch (err) {
+            message.error(err instanceof Error ? err.message : '重新排队失败');
+        }
+    }, [startPolling, worldDetail]);
+    useEffect(() => {
+        if (selectedWorldId == null && worlds.length > 0) {
+            setSelectedWorldId(worlds[0].id);
+        }
+    }, [selectedWorldId, worlds]);
+    const metadataValue: MetadataFormValue | undefined = worldDetail
+        ? {
+            name: worldDetail.world.name ?? '',
+            tagline: worldDetail.world.tagline ?? '',
+            themes: worldDetail.world.themes ?? [],
+            creativeIntent: worldDetail.world.creativeIntent ?? '',
+            notes: worldDetail.world.notes ?? '',
+        }
+        : undefined;
+    const moduleDefinitions: WorldModuleDefinition[] = definitions?.modules ?? [];
+    const canPublish = worldDetail ? worldDetail.world.status !== 'GENERATING' && !publishing : false;
+
+    return (
+        <Layout style={{ minHeight: '100vh', background: '#f5f6fa' }}>
+            <Content style={{ padding: '24px 48px 80px' }}>
+                <Spin spinning={loadingDefinitions || loadingDetail} tip="加载中...">
+                    <Space direction="vertical" size={16} style={{ width: '100%' }}>
+                        <Title level={2}>世界构建</Title>
+                        <Paragraph type="secondary">
+                            管理世界观设定、调用 AI 生成模块内容，并跟踪正式创建的生成进度。
+                        </Paragraph>
+                        <WorldSelectorPanel
+                            worlds={publishedWorlds}
+                            drafts={draftWorlds}
+                            selectedWorldId={selectedWorldId}
+                            selectedWorld={selectedWorldSummary}
+                            loading={loadingWorlds}
+                            creating={creating}
+                            onSelectWorld={handleSelectWorld}
+                            onCreateWorld={handleCreateWorld}
+                            onRenameDraft={handleRenameDraft}
+                            onDeleteDraft={handleDeleteDraft}
+                        />
+                        {worldDetail && metadataValue ? (
+                            <>
+                                <MetadataForm
+                                    value={metadataValue}
+                                    definition={definitions?.basicInfo}
+                                    disabled={isEditingDisabled}
+                                    onChange={handleMetadataChange}
+                                />
+                                {isEditingDisabled && (
+                                    <Alert
+                                        type="info"
+                                        showIcon
+                                        message="世界正在生成完整信息"
+                                        description="生成完成前暂不可编辑字段，进度将在下方实时更新。"
+                                        style={{ marginBottom: 16 }}
+                                    />
+                                )}
+                                <ModuleTabs
+                                    modules={worldDetail.modules}
+                                    definitions={moduleDefinitions}
+                                    disabled={isEditingDisabled}
+                                    generatingModules={moduleLoadingKeys}
+                                    onFieldChange={handleFieldChange}
+                                    onOpenRefine={handleOpenRefine}
+                                    onGenerateModule={handleGenerateModule}
+                                    onViewFullContent={handleViewFullContent}
+                                />
+                            </>
+                        ) : (
+                            <Empty description={loadingDetail ? '正在加载世界详情' : '请选择一个世界或新建草稿'} />
+                        )}
+                    </Space>
+                </Spin>
+            </Content>
+            <StickyFooterBar
+                worldStatus={worldDetail?.world.status}
+                version={worldDetail?.world.version}
+                saveState={saveState}
+                hasUnsavedChanges={hasUnsavedChanges}
+                onSave={() => { void saveDraft({ silent: false }); }}
+                onPublish={handlePublish}
+                savingDisabled={!worldDetail || isEditingDisabled}
+                publishing={publishing}
+                canPublish={canPublish}
+            />
+            <GenerationProgressModal
+                open={progressVisible}
+                status={progressStatus}
+                worldName={worldDetail?.world.name}
+                loading={progressLoading}
+                onClose={() => {
+                    setProgressVisible(false);
+                    stopPolling();
+                }}
+                onRetry={handleRetryModule}
+            />
+            {refineState && (
+                <RefineModal
+                    open={!!refineState}
+                    onCancel={() => setRefineState(null)}
+                    originalText={refineState.text}
+                    contextType={`世界构建 · ${refineState.moduleLabel} / ${refineState.fieldLabel}`}
+                    onRefined={handleApplyRefine}
+                    onRequest={handleRefineRequest}
+                />
+            )}
+        </Layout>
+    );
+};
+
+export default WorldBuilderPage;

--- a/frontend/src/pages/WorldBuilder/components/FieldCard.tsx
+++ b/frontend/src/pages/WorldBuilder/components/FieldCard.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Button, Card, Space, Tooltip, Typography } from 'antd';
+import TextArea from 'antd/es/input/TextArea';
+import { InfoCircleOutlined } from '@ant-design/icons';
+
+const { Text } = Typography;
+
+const SparklesSvg = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="1em" height="1em">
+        <path d="M11.5 2.75a.75.75 0 0 1 1.44 0l.862 2.649a3.25 3.25 0 0 0 2.046 2.046l2.649.862a.75.75 0 0 1 0 1.44l-2.649.862a3.25 3.25 0 0 0-2.046 2.046l-.862 2.649a.75.75 0 0 1-1.44 0l-.862-2.649a3.25 3.25 0 0 0-2.046-2.046l-2.649-.862a.75.75 0 0 1 0-1.44l2.649-.862a3.25 3.25 0 0 0 2.046-2.046Z" />
+        <path d="M5 3.75a.75.75 0 0 1 .75.75v1a2.5 2.5 0 0 0 2.5 2.5h1a.75.75 0 0 1 0 1.5h-1A2.5 2.5 0 0 0 5.75 12v1a.75.75 0 0 1-1.5 0v-1A2.5 2.5 0 0 0 1.75 8.5h-1a.75.75 0 0 1 0-1.5h1A2.5 2.5 0 0 0 4.25 5.5v-1A.75.75 0 0 1 5 3.75Zm13.75 7.5a.75.75 0 0 1 .75.75v.5a1.75 1.75 0 0 0 1.75 1.75h.5a.75.75 0 0 1 0 1.5h-.5A1.75 1.75 0 0 0 19.5 17v.5a.75.75 0 0 1-1.5 0V17a1.75 1.75 0 0 0-1.75-1.75h-.5a.75.75 0 0 1 0-1.5h.5A1.75 1.75 0 0 0 18 12v-.5a.75.75 0 0 1 .75-.75Z" />
+    </svg>
+);
+
+const SparklesIcon: React.FC = () => <SparklesSvg />;
+
+type FieldCardProps = {
+    label: string;
+    tooltip?: string;
+    required?: boolean;
+    recommendedLength?: string;
+    value: string;
+    disabled?: boolean;
+    onChange: (value: string) => void;
+    onOptimize: () => void;
+};
+
+const FieldCard: React.FC<FieldCardProps> = ({
+    label,
+    tooltip,
+    required,
+    recommendedLength,
+    value,
+    disabled,
+    onChange,
+    onOptimize,
+}) => {
+    const length = value?.length ?? 0;
+    return (
+        <Card size="small" style={{ marginBottom: 16 }}>
+            <Space style={{ width: '100%', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                <Space size={6} align="center">
+                    <Text strong>
+                        {label}
+                        {required ? ' *' : ''}
+                    </Text>
+                    {tooltip && (
+                        <Tooltip title={tooltip}>
+                            <InfoCircleOutlined style={{ color: '#8c8c8c' }} />
+                        </Tooltip>
+                    )}
+                </Space>
+                <Space size={12} align="center">
+                    {recommendedLength && <Text type="secondary">{recommendedLength}</Text>}
+                    <Button icon={<SparklesIcon />} size="small" onClick={onOptimize} disabled={disabled}>
+                        AI 优化
+                    </Button>
+                </Space>
+            </Space>
+            <TextArea
+                style={{ marginTop: 12 }}
+                value={value}
+                onChange={e => onChange(e.target.value)}
+                disabled={disabled}
+                autoSize={{ minRows: 4, maxRows: 10 }}
+                placeholder="填写具体设定内容"
+            />
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 8 }}>
+                <Text type="secondary">字数：{length}</Text>
+                {disabled && <Text type="secondary">生成过程中暂不可编辑</Text>}
+            </div>
+        </Card>
+    );
+};
+
+export default FieldCard;

--- a/frontend/src/pages/WorldBuilder/components/GenerationProgressModal.tsx
+++ b/frontend/src/pages/WorldBuilder/components/GenerationProgressModal.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { Button, Modal, Space, Table, Tag, Typography } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import type { WorldGenerationJobStatusEntry, WorldGenerationStatus, WorldGenerationJobStatus } from '../../../types';
+
+const { Text } = Typography;
+
+type GenerationProgressModalProps = {
+    open: boolean;
+    status: WorldGenerationStatus | null;
+    worldName?: string;
+    loading?: boolean;
+    onClose: () => void;
+    onRetry: (moduleKey: string) => void;
+};
+
+const jobStatusMeta: Record<WorldGenerationJobStatus, { text: string; color: string }> = {
+    WAITING: { text: '等待中', color: 'default' },
+    RUNNING: { text: '生成中', color: 'processing' },
+    SUCCEEDED: { text: '已完成', color: 'success' },
+    FAILED: { text: '失败', color: 'error' },
+    CANCELLED: { text: '已取消', color: 'warning' },
+};
+
+const formatDateTime = (value?: string | null) => {
+    if (!value) return '—';
+    try {
+        return new Date(value).toLocaleString();
+    } catch {
+        return value;
+    }
+};
+
+const GenerationProgressModal: React.FC<GenerationProgressModalProps> = ({ open, status, worldName, loading, onClose, onRetry }) => {
+    const columns: ColumnsType<WorldGenerationJobStatusEntry> = [
+        {
+            title: '模块',
+            dataIndex: 'moduleLabel',
+            key: 'moduleLabel',
+        },
+        {
+            title: '状态',
+            dataIndex: 'status',
+            key: 'status',
+            render: value => {
+                const meta = jobStatusMeta[value as WorldGenerationJobStatus];
+                return <Tag color={meta?.color}>{meta?.text ?? value}</Tag>;
+            },
+        },
+        {
+            title: '重试次数',
+            dataIndex: 'attempts',
+            key: 'attempts',
+            width: 100,
+            render: value => value ?? 0,
+        },
+        {
+            title: '开始时间',
+            dataIndex: 'startedAt',
+            key: 'startedAt',
+            render: value => formatDateTime(value as string | undefined),
+        },
+        {
+            title: '结束时间',
+            dataIndex: 'finishedAt',
+            key: 'finishedAt',
+            render: value => formatDateTime(value as string | undefined),
+        },
+        {
+            title: '错误信息',
+            dataIndex: 'error',
+            key: 'error',
+            render: value => (value ? <Text type="danger">{value}</Text> : '—'),
+        },
+        {
+            title: '操作',
+            key: 'action',
+            width: 140,
+            render: (_, record) => (
+                <Button
+                    size="small"
+                    onClick={() => onRetry(record.moduleKey)}
+                    disabled={record.status !== 'FAILED'}
+                >
+                    重新排队
+                </Button>
+            ),
+        },
+    ];
+
+    const isGenerating = status?.status === 'GENERATING';
+
+    return (
+        <Modal
+            title="世界完整信息生成进度"
+            open={open}
+            onCancel={isGenerating ? undefined : onClose}
+            closable={!isGenerating}
+            maskClosable={false}
+            footer={
+                <Button type="primary" onClick={onClose} disabled={isGenerating}>
+                    {isGenerating ? '生成完成后可关闭' : '关闭'}
+                </Button>
+            }
+            width={800}
+        >
+            <Space direction="vertical" style={{ width: '100%' }} size={16}>
+                <div>
+                    <Text strong>{worldName || '当前世界'}</Text>
+                    <Text style={{ marginLeft: 12 }}>状态：{status?.status || '—'}</Text>
+                </div>
+                <Table
+                    size="small"
+                    rowKey="moduleKey"
+                    columns={columns}
+                    dataSource={status?.queue ?? []}
+                    loading={loading}
+                    pagination={false}
+                />
+            </Space>
+        </Modal>
+    );
+};
+
+export default GenerationProgressModal;

--- a/frontend/src/pages/WorldBuilder/components/MetadataForm.tsx
+++ b/frontend/src/pages/WorldBuilder/components/MetadataForm.tsx
@@ -1,0 +1,111 @@
+import React, { useMemo } from 'react';
+import { Card, Form, Input, Select, Space, Tooltip, Typography } from 'antd';
+import { InfoCircleOutlined } from '@ant-design/icons';
+import type { WorldBasicInfoDefinition, WorldFieldDefinition } from '../../../types';
+
+export type MetadataFormValue = {
+    name: string;
+    tagline: string;
+    themes: string[];
+    creativeIntent: string;
+    notes?: string | null;
+};
+
+type MetadataFormProps = {
+    value?: MetadataFormValue;
+    definition?: WorldBasicInfoDefinition;
+    disabled?: boolean;
+    onChange: <K extends keyof MetadataFormValue>(field: K, value: MetadataFormValue[K]) => void;
+};
+
+const renderLabel = (definition?: WorldFieldDefinition) => {
+    if (!definition) return null;
+    return (
+        <Space size={4} align="center">
+            <span>{definition.label}</span>
+            {definition.tooltip && (
+                <Tooltip title={definition.tooltip} placement="top">
+                    <InfoCircleOutlined style={{ color: '#8c8c8c' }} />
+                </Tooltip>
+            )}
+        </Space>
+    );
+};
+
+const MetadataForm: React.FC<MetadataFormProps> = ({ value, definition, disabled, onChange }) => {
+    const definitionMap = useMemo(() => {
+        const entries = definition?.fields?.map(field => [field.key, field] as const) ?? [];
+        return Object.fromEntries(entries) as Record<string, WorldFieldDefinition>;
+    }, [definition]);
+
+    if (!value) {
+        return null;
+    }
+
+    return (
+        <Card title="基础信息" style={{ marginBottom: 16 }}>
+            {definition?.description && (
+                <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
+                    {definition.description}
+                </Typography.Paragraph>
+            )}
+            <Form layout="vertical" style={{ maxWidth: 960 }}>
+                <Form.Item label={renderLabel(definitionMap.name)} extra={definitionMap.name?.recommendedLength} required>
+                    <Input
+                        value={value.name}
+                        disabled={disabled}
+                        onChange={e => onChange('name', e.target.value)}
+                        placeholder="请输入世界名称"
+                        maxLength={80}
+                    />
+                </Form.Item>
+                <Form.Item label={renderLabel(definitionMap.tagline)} extra={definitionMap.tagline?.recommendedLength} required>
+                    <Input
+                        value={value.tagline}
+                        disabled={disabled}
+                        onChange={e => onChange('tagline', e.target.value)}
+                        placeholder="请输入一句话概述"
+                        maxLength={180}
+                    />
+                </Form.Item>
+                <Form.Item label={renderLabel(definitionMap.themes)} extra="可输入 1-5 个主题标签" required>
+                    <Select
+                        mode="tags"
+                        disabled={disabled}
+                        value={value.themes}
+                        onChange={items => onChange('themes', items as string[])}
+                        tokenSeparators={[',', ' ', '、']}
+                        placeholder="添加主题标签"
+                    />
+                </Form.Item>
+                <Form.Item
+                    label={renderLabel(definitionMap.creativeIntent)}
+                    extra={definitionMap.creativeIntent?.recommendedLength}
+                    required
+                >
+                    <Input.TextArea
+                        value={value.creativeIntent}
+                        disabled={disabled}
+                        onChange={e => onChange('creativeIntent', e.target.value)}
+                        autoSize={{ minRows: 4, maxRows: 8 }}
+                        placeholder="描述创作意图、灵感来源与创作边界"
+                    />
+                </Form.Item>
+                <Form.Item
+                    label={renderLabel(definitionMap.notes)}
+                    extra={definitionMap.notes?.recommendedLength}
+                >
+                    <Input.TextArea
+                        value={value.notes ?? ''}
+                        disabled={disabled}
+                        onChange={e => onChange('notes', e.target.value)}
+                        autoSize={{ minRows: 2, maxRows: 6 }}
+                        placeholder="（可选）补充开发者备注"
+                    />
+                </Form.Item>
+            </Form>
+        </Card>
+    );
+};
+
+export default MetadataForm;

--- a/frontend/src/pages/WorldBuilder/components/ModuleTabs.tsx
+++ b/frontend/src/pages/WorldBuilder/components/ModuleTabs.tsx
@@ -1,0 +1,132 @@
+import React, { useMemo } from 'react';
+import { Alert, Button, Card, Empty, Space, Tabs, Tag, Typography } from 'antd';
+import type { TabsProps } from 'antd';
+import FieldCard from './FieldCard';
+import type { WorldModule, WorldModuleDefinition, WorldModuleStatus } from '../../../types';
+
+const { Text, Paragraph } = Typography;
+
+type ModuleTabsProps = {
+    modules: WorldModule[];
+    definitions: WorldModuleDefinition[];
+    disabled?: boolean;
+    generatingModules: Set<string>;
+    onFieldChange: (moduleKey: string, fieldKey: string, value: string) => void;
+    onOpenRefine: (moduleKey: string, fieldKey: string, fieldLabel: string, originalText: string) => void;
+    onGenerateModule: (moduleKey: string) => void;
+    onViewFullContent: (moduleKey: string, label: string, content: string) => void;
+};
+
+const moduleStatusMeta: Record<WorldModuleStatus, { color: string; text: string }> = {
+    EMPTY: { color: 'default', text: '未填写' },
+    IN_PROGRESS: { color: 'processing', text: '填写中' },
+    READY: { color: 'warning', text: '待发布' },
+    AWAITING_GENERATION: { color: 'purple', text: '待生成' },
+    GENERATING: { color: 'processing', text: '生成中' },
+    COMPLETED: { color: 'success', text: '已完成' },
+    FAILED: { color: 'error', text: '生成失败' },
+};
+
+const ModuleTabs: React.FC<ModuleTabsProps> = ({
+    modules,
+    definitions,
+    disabled,
+    generatingModules,
+    onFieldChange,
+    onOpenRefine,
+    onGenerateModule,
+    onViewFullContent,
+}) => {
+    const moduleMap = useMemo(() => new Map(modules.map(module => [module.key, module])), [modules]);
+
+    if (!definitions.length) {
+        return <Empty description="暂无模块定义" />;
+    }
+
+    const items: TabsProps['items'] = definitions.map(definition => {
+        const module = moduleMap.get(definition.key);
+        const status = module?.status ?? 'EMPTY';
+        const statusMeta = moduleStatusMeta[status];
+        const isGenerating = generatingModules.has(definition.key);
+        const fieldDisabled = disabled || status === 'GENERATING';
+        const canViewFullContent = Boolean(module?.fullContent);
+
+        return {
+            key: definition.key,
+            label: (
+                <Space size={8}>
+                    <span>{definition.label}</span>
+                    <Tag color={statusMeta.color}>{statusMeta.text}</Tag>
+                </Space>
+            ),
+            children: (
+                <div>
+                    <Card size="small" bordered={false} style={{ background: '#f6f8ff', marginBottom: 16 }}>
+                        <Space style={{ width: '100%', justifyContent: 'space-between', alignItems: 'flex-start' }} wrap>
+                            <Space direction="vertical" size={4} style={{ maxWidth: '70%' }}>
+                                <Text strong>{definition.label}</Text>
+                                {definition.description && (
+                                    <Paragraph type="secondary" style={{ marginBottom: 0 }}>
+                                        {definition.description}
+                                    </Paragraph>
+                                )}
+                            </Space>
+                            <Space size={8} wrap>
+                                {canViewFullContent && (
+                                    <Button
+                                        size="small"
+                                        onClick={() => onViewFullContent(definition.key, definition.label, module?.fullContent ?? '')}
+                                    >
+                                        查看完整信息
+                                    </Button>
+                                )}
+                                <Button
+                                    size="small"
+                                    type="primary"
+                                    ghost
+                                    onClick={() => onGenerateModule(definition.key)}
+                                    loading={isGenerating}
+                                    disabled={disabled}
+                                >
+                                    AI 自动生成本模块
+                                </Button>
+                            </Space>
+                        </Space>
+                    </Card>
+
+                    {status === 'FAILED' && (
+                        <Alert
+                            type="error"
+                            showIcon
+                            message={`${definition.label} 生成失败`}
+                            description="请检查字段内容后重新排队或修改文本。"
+                            style={{ marginBottom: 16 }}
+                        />
+                    )}
+
+                    {definition.fields.map(field => (
+                        <FieldCard
+                            key={field.key}
+                            label={field.label}
+                            tooltip={field.tooltip}
+                            required
+                            recommendedLength={field.recommendedLength}
+                            value={module?.fields?.[field.key] ?? ''}
+                            disabled={fieldDisabled || disabled}
+                            onChange={text => onFieldChange(definition.key, field.key, text)}
+                            onOptimize={() => onOpenRefine(definition.key, field.key, field.label, module?.fields?.[field.key] ?? '')}
+                        />
+                    ))}
+                </div>
+            ),
+        };
+    });
+
+    return (
+        <Card style={{ marginTop: 16 }}>
+            <Tabs items={items} destroyInactiveTabPane={false} />
+        </Card>
+    );
+};
+
+export default ModuleTabs;

--- a/frontend/src/pages/WorldBuilder/components/StickyFooterBar.tsx
+++ b/frontend/src/pages/WorldBuilder/components/StickyFooterBar.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Button, Space, Typography } from 'antd';
+import type { WorldStatus } from '../../../types';
+
+const { Text } = Typography;
+
+export type SaveState = 'saved' | 'saving' | 'pending' | 'error';
+
+type StickyFooterBarProps = {
+    worldStatus?: WorldStatus;
+    version?: number | null;
+    saveState: SaveState;
+    hasUnsavedChanges: boolean;
+    onSave: () => void;
+    onPublish: () => void;
+    savingDisabled?: boolean;
+    publishing: boolean;
+    canPublish: boolean;
+};
+
+const worldStatusLabel: Record<WorldStatus, string> = {
+    DRAFT: '草稿',
+    GENERATING: '生成中',
+    ACTIVE: '已发布',
+    ARCHIVED: '已归档',
+};
+
+const saveStateLabel: Record<SaveState, { text: string; color: string }> = {
+    saved: { text: '已保存', color: '#52c41a' },
+    saving: { text: '保存中…', color: '#1677ff' },
+    pending: { text: '存在未保存的修改', color: '#faad14' },
+    error: { text: '保存失败，请重试', color: '#ff4d4f' },
+};
+
+const StickyFooterBar: React.FC<StickyFooterBarProps> = ({
+    worldStatus,
+    version,
+    saveState,
+    hasUnsavedChanges,
+    onSave,
+    onPublish,
+    savingDisabled,
+    publishing,
+    canPublish,
+}) => {
+    const statusText = worldStatus ? worldStatusLabel[worldStatus] : '未选择世界';
+    const saveMeta = saveStateLabel[saveState];
+
+    return (
+        <div
+            style={{
+                position: 'sticky',
+                bottom: 0,
+                background: '#fff',
+                borderTop: '1px solid #f0f0f0',
+                padding: '12px 24px',
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                zIndex: 10,
+            }}
+        >
+            <Space direction="vertical" size={0}>
+                <Text strong>{statusText}{typeof version === 'number' ? ` · 版本 ${version}` : ''}</Text>
+                <Text style={{ color: saveMeta.color }}>{saveMeta.text}</Text>
+            </Space>
+            <Space size={12}>
+                <Button
+                    onClick={onSave}
+                    disabled={savingDisabled || (!hasUnsavedChanges && saveState !== 'error')}
+                    loading={saveState === 'saving'}
+                >
+                    保存草稿
+                </Button>
+                <Button
+                    type="primary"
+                    onClick={onPublish}
+                    disabled={!canPublish}
+                    loading={publishing}
+                >
+                    正式创建世界
+                </Button>
+            </Space>
+        </div>
+    );
+};
+
+export default StickyFooterBar;

--- a/frontend/src/pages/WorldBuilder/components/WorldSelectorPanel.tsx
+++ b/frontend/src/pages/WorldBuilder/components/WorldSelectorPanel.tsx
@@ -1,0 +1,274 @@
+import React, { useMemo, useState } from 'react';
+import {
+    Badge,
+    Button,
+    Card,
+    Drawer,
+    Input,
+    List,
+    Modal,
+    Popconfirm,
+    Select,
+    Space,
+    Tag,
+    Typography,
+} from 'antd';
+import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
+import type { SelectProps } from 'antd';
+import type { WorldStatus, WorldSummary, WorldModuleStatus } from '../../../types';
+
+type WorldSelectorPanelProps = {
+    worlds: WorldSummary[];
+    drafts: WorldSummary[];
+    selectedWorldId: number | null;
+    selectedWorld?: WorldSummary;
+    loading?: boolean;
+    creating?: boolean;
+    onSelectWorld: (worldId: number) => void;
+    onCreateWorld: () => void;
+    onRenameDraft: (worldId: number, nextName: string) => Promise<void>;
+    onDeleteDraft: (worldId: number) => Promise<void>;
+};
+
+const statusLabels: Record<WorldStatus, string> = {
+    DRAFT: '草稿',
+    GENERATING: '生成中',
+    ACTIVE: '已发布',
+    ARCHIVED: '已归档',
+};
+
+const statusColors: Record<WorldStatus, string> = {
+    DRAFT: 'default',
+    GENERATING: 'processing',
+    ACTIVE: 'success',
+    ARCHIVED: 'warning',
+};
+
+const moduleStatusLabelMap: Record<WorldModuleStatus, string> = {
+    EMPTY: '未填写',
+    IN_PROGRESS: '填写中',
+    READY: '待发布',
+    AWAITING_GENERATION: '待生成',
+    GENERATING: '生成中',
+    COMPLETED: '已生成',
+    FAILED: '生成失败',
+};
+
+const formatDateTime = (value?: string | null) => {
+    if (!value) return '—';
+    try {
+        return new Date(value).toLocaleString();
+    } catch {
+        return value;
+    }
+};
+
+const WorldSelectorPanel: React.FC<WorldSelectorPanelProps> = ({
+    worlds,
+    drafts,
+    selectedWorldId,
+    selectedWorld,
+    loading,
+    creating,
+    onSelectWorld,
+    onCreateWorld,
+    onRenameDraft,
+    onDeleteDraft,
+}) => {
+    const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+    const [renameTarget, setRenameTarget] = useState<WorldSummary | null>(null);
+    const [renameValue, setRenameValue] = useState('');
+    const [renameLoading, setRenameLoading] = useState(false);
+    const [deletingId, setDeletingId] = useState<number | null>(null);
+
+    const publishedOptions = useMemo<SelectProps['options']>(() => (
+        worlds.map(world => ({
+            value: world.id,
+            label: (
+                <Space size={8}>
+                    <span>{world.name}</span>
+                    <Tag color={statusColors[world.status]}>{statusLabels[world.status]}</Tag>
+                </Space>
+            ),
+        }))
+    ), [worlds]);
+
+    const statusCounts = useMemo(() => {
+        if (!selectedWorld) return [] as React.ReactNode[];
+        const counts = new Map<string, number>();
+        Object.values(selectedWorld.moduleProgress || {}).forEach(status => {
+            const key = moduleStatusLabelMap[status] || status;
+            counts.set(key, (counts.get(key) || 0) + 1);
+        });
+        return Array.from(counts.entries()).map(([label, count]) => (
+            <Tag key={label}>{label}：{count}</Tag>
+        ));
+    }, [selectedWorld]);
+
+    const handleRenameConfirm = async () => {
+        if (!renameTarget) return;
+        const nextName = renameValue.trim();
+        if (!nextName) {
+            return;
+        }
+        setRenameLoading(true);
+        try {
+            await onRenameDraft(renameTarget.id, nextName);
+            setRenameTarget(null);
+            setRenameValue('');
+        } finally {
+            setRenameLoading(false);
+        }
+    };
+
+    const handleDeleteDraft = async (worldId: number) => {
+        setDeletingId(worldId);
+        try {
+            await onDeleteDraft(worldId);
+        } finally {
+            setDeletingId(null);
+        }
+    };
+
+    const draftList = (
+        <List
+            dataSource={drafts}
+            locale={{ emptyText: '暂无草稿世界' }}
+            renderItem={draft => (
+                <List.Item
+                    key={draft.id}
+                    actions={[
+                        <Button key="edit" type="link" onClick={() => { onSelectWorld(draft.id); setIsDrawerOpen(false); }}>
+                            继续编辑
+                        </Button>,
+                        <Button
+                            key="rename"
+                            type="link"
+                            icon={<EditOutlined />}
+                            onClick={() => {
+                                setRenameTarget(draft);
+                                setRenameValue(draft.name);
+                            }}
+                        >
+                            重命名
+                        </Button>,
+                        <Popconfirm
+                            key="delete"
+                            title="删除草稿"
+                            description="删除后不可恢复，确定要删除该草稿吗？"
+                            okType="danger"
+                            onConfirm={() => handleDeleteDraft(draft.id)}
+                        >
+                            <Button type="link" danger icon={<DeleteOutlined />} loading={deletingId === draft.id}>
+                                删除
+                            </Button>
+                        </Popconfirm>,
+                    ]}
+                >
+                    <List.Item.Meta
+                        title={draft.name}
+                        description={
+                            <Space direction="vertical" size={0}>
+                                <Typography.Text type="secondary">最近更新：{formatDateTime(draft.updatedAt)}</Typography.Text>
+                                <Space size={4} wrap>
+                                    {draft.themes.map(theme => (
+                                        <Tag key={theme} color="blue">{theme}</Tag>
+                                    ))}
+                                </Space>
+                            </Space>
+                        }
+                    />
+                </List.Item>
+            )}
+        />
+    );
+
+    return (
+        <Card>
+            <Space style={{ width: '100%', justifyContent: 'space-between', flexWrap: 'wrap' }}>
+                <Space size={12} wrap>
+                    <Button type="primary" icon={<PlusOutlined />} onClick={onCreateWorld} loading={creating}>
+                        新建世界
+                    </Button>
+                    <Select
+                        placeholder="选择已创建的世界"
+                        style={{ minWidth: 260 }}
+                        value={selectedWorldId ?? undefined}
+                        onChange={value => onSelectWorld(Number(value))}
+                        options={publishedOptions}
+                        loading={loading}
+                    />
+                    <Badge count={drafts.length} offset={[4, -2]}>
+                        <Button onClick={() => setIsDrawerOpen(true)}>草稿列表</Button>
+                    </Badge>
+                </Space>
+            </Space>
+
+            <div style={{ marginTop: 16 }}>
+                {selectedWorld ? (
+                    <Card size="small" bordered={false} style={{ background: '#f7f9fc' }}>
+                        <Space direction="vertical" style={{ width: '100%' }} size={8}>
+                            <Space wrap>
+                                <Tag color={statusColors[selectedWorld.status]}>{statusLabels[selectedWorld.status]}</Tag>
+                                {typeof selectedWorld.version === 'number' && (
+                                    <Tag color="purple">版本 {selectedWorld.version}</Tag>
+                                )}
+                                <Typography.Text type="secondary">
+                                    最近更新：{formatDateTime(selectedWorld.updatedAt)}
+                                </Typography.Text>
+                                {selectedWorld.publishedAt && (
+                                    <Typography.Text type="secondary">
+                                        首次发布：{formatDateTime(selectedWorld.publishedAt)}
+                                    </Typography.Text>
+                                )}
+                            </Space>
+                            <Typography.Paragraph style={{ marginBottom: 0 }}>
+                                <Typography.Text strong>一句话概述：</Typography.Text> {selectedWorld.tagline || '—'}
+                            </Typography.Paragraph>
+                            <Space size={4} wrap>
+                                {selectedWorld.themes.map(theme => (
+                                    <Tag color="geekblue" key={theme}>{theme}</Tag>
+                                ))}
+                            </Space>
+                            {statusCounts.length > 0 && (
+                                <Space size={4} wrap>
+                                    <Typography.Text type="secondary">模块状态：</Typography.Text>
+                                    {statusCounts.map(node => node)}
+                                </Space>
+                            )}
+                        </Space>
+                    </Card>
+                ) : (
+                    <Typography.Text type="secondary">请选择或新建一个世界以开始编辑。</Typography.Text>
+                )}
+            </div>
+
+            <Drawer
+                title="草稿世界"
+                open={isDrawerOpen}
+                onClose={() => setIsDrawerOpen(false)}
+                width={420}
+            >
+                {draftList}
+            </Drawer>
+
+            <Modal
+                title="重命名草稿世界"
+                open={!!renameTarget}
+                onCancel={() => setRenameTarget(null)}
+                onOk={handleRenameConfirm}
+                confirmLoading={renameLoading}
+                okText="保存"
+            >
+                <Input
+                    placeholder="请输入新的世界名称"
+                    value={renameValue}
+                    onChange={e => setRenameValue(e.target.value)}
+                    maxLength={80}
+                />
+            </Modal>
+        </Card>
+    );
+};
+
+export default WorldSelectorPanel;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,25 @@
-import type { StoryCard, CharacterCard, Outline, ConceptionFormValues, Chapter, Manuscript, ManuscriptSection, CharacterChangeLog, CharacterDialogueRequestPayload, CharacterDialogueResponsePayload, PromptTemplatesResponse, PromptTemplatesUpdatePayload, PromptTemplateMetadata, WorldBuildingDefinitionsResponse } from '../types';
+import type {
+    StoryCard,
+    CharacterCard,
+    Outline,
+    ConceptionFormValues,
+    Chapter,
+    Manuscript,
+    ManuscriptSection,
+    CharacterChangeLog,
+    CharacterDialogueRequestPayload,
+    CharacterDialogueResponsePayload,
+    PromptTemplatesResponse,
+    PromptTemplatesUpdatePayload,
+    PromptTemplateMetadata,
+    WorldBuildingDefinitionsResponse,
+    WorldDetail,
+    WorldSummary,
+    WorldPublishPreview,
+    WorldPublishResponse,
+    WorldGenerationStatus,
+    WorldModule,
+} from '../types';
 
 /**
  * Creates authorization headers for API requests.
@@ -374,6 +395,117 @@ export const fetchPromptTemplateMetadata = (): Promise<PromptTemplateMetadata> =
 export const fetchWorldBuildingDefinitions = (): Promise<WorldBuildingDefinitionsResponse> => {
     return fetch('/api/v1/world-building/definitions', { headers: getAuthHeaders() })
         .then(res => handleResponse<WorldBuildingDefinitionsResponse>(res));
+};
+
+// World building APIs
+
+export type WorldUpsertPayload = {
+    name: string;
+    tagline: string;
+    themes: string[];
+    creativeIntent: string;
+    notes?: string | null;
+};
+
+export const createWorld = (payload: WorldUpsertPayload): Promise<WorldDetail> => {
+    return fetch('/api/v1/worlds', {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(payload),
+    }).then(res => handleResponse<WorldDetail>(res));
+};
+
+export const fetchWorlds = (status?: string): Promise<WorldSummary[]> => {
+    const query = status ? `?status=${encodeURIComponent(status)}` : '';
+    return fetch(`/api/v1/worlds${query}`, { headers: getAuthHeaders() })
+        .then(res => handleResponse<WorldSummary[]>(res));
+};
+
+export const fetchWorldDetail = (worldId: number): Promise<WorldDetail> => {
+    return fetch(`/api/v1/worlds/${worldId}`, { headers: getAuthHeaders() })
+        .then(res => handleResponse<WorldDetail>(res));
+};
+
+export const updateWorld = (worldId: number, payload: WorldUpsertPayload): Promise<WorldDetail> => {
+    return fetch(`/api/v1/worlds/${worldId}`, {
+        method: 'PUT',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(payload),
+    }).then(res => handleResponse<WorldDetail>(res));
+};
+
+export const deleteWorld = (worldId: number): Promise<void> => {
+    return fetch(`/api/v1/worlds/${worldId}`, {
+        method: 'DELETE',
+        headers: getAuthHeaders(),
+    }).then(res => handleResponse<void>(res));
+};
+
+export const updateWorldModule = (
+    worldId: number,
+    moduleKey: string,
+    fields: Record<string, string>
+): Promise<WorldModule> => {
+    return fetch(`/api/v1/worlds/${worldId}/modules/${moduleKey}`, {
+        method: 'PUT',
+        headers: getAuthHeaders(),
+        body: JSON.stringify({ fields }),
+    }).then(res => handleResponse<WorldModule>(res));
+};
+
+export const updateWorldModules = (
+    worldId: number,
+    modules: { key: string; fields: Record<string, string> }[]
+): Promise<WorldModule[]> => {
+    return fetch(`/api/v1/worlds/${worldId}/modules`, {
+        method: 'PUT',
+        headers: getAuthHeaders(),
+        body: JSON.stringify({ modules }),
+    }).then(res => handleResponse<WorldModule[]>(res));
+};
+
+export const generateWorldModule = (worldId: number, moduleKey: string): Promise<WorldModule> => {
+    return fetch(`/api/v1/worlds/${worldId}/modules/${moduleKey}/generate`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+    }).then(res => handleResponse<WorldModule>(res));
+};
+
+export const refineWorldField = (
+    worldId: number,
+    moduleKey: string,
+    fieldKey: string,
+    payload: { text: string; instruction?: string }
+): Promise<{ result: string }> => {
+    return fetch(`/api/v1/worlds/${worldId}/modules/${moduleKey}/fields/${fieldKey}/refine`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(payload),
+    }).then(res => handleResponse<{ result: string }>(res));
+};
+
+export const previewWorldPublish = (worldId: number): Promise<WorldPublishPreview> => {
+    return fetch(`/api/v1/worlds/${worldId}/publish/preview`, { headers: getAuthHeaders() })
+        .then(res => handleResponse<WorldPublishPreview>(res));
+};
+
+export const publishWorld = (worldId: number): Promise<WorldPublishResponse> => {
+    return fetch(`/api/v1/worlds/${worldId}/publish`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+    }).then(res => handleResponse<WorldPublishResponse>(res));
+};
+
+export const fetchWorldGenerationStatus = (worldId: number): Promise<WorldGenerationStatus> => {
+    return fetch(`/api/v1/worlds/${worldId}/generation`, { headers: getAuthHeaders() })
+        .then(res => handleResponse<WorldGenerationStatus>(res));
+};
+
+export const retryWorldGeneration = (worldId: number, moduleKey: string): Promise<void> => {
+    return fetch(`/api/v1/worlds/${worldId}/generation/${moduleKey}/retry`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+    }).then(res => handleResponse<void>(res));
 };
 
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -241,6 +241,109 @@ export interface WorldBuildingDefinitionsResponse {
     promptContext: WorldPromptContextDefinition;
 }
 
+export type WorldStatus = 'DRAFT' | 'GENERATING' | 'ACTIVE' | 'ARCHIVED';
+
+export type WorldModuleStatus =
+    | 'EMPTY'
+    | 'IN_PROGRESS'
+    | 'READY'
+    | 'AWAITING_GENERATION'
+    | 'GENERATING'
+    | 'COMPLETED'
+    | 'FAILED';
+
+export type WorldGenerationJobStatus =
+    | 'WAITING'
+    | 'RUNNING'
+    | 'SUCCEEDED'
+    | 'FAILED'
+    | 'CANCELLED';
+
+export interface WorldSummary {
+    id: number;
+    name: string;
+    tagline: string;
+    themes: string[];
+    status: WorldStatus;
+    version?: number | null;
+    updatedAt?: string | null;
+    publishedAt?: string | null;
+    moduleProgress: Record<string, WorldModuleStatus>;
+}
+
+export interface WorldBasicInfo {
+    id?: number;
+    name: string;
+    tagline: string;
+    themes: string[];
+    creativeIntent: string;
+    notes?: string | null;
+    status: WorldStatus;
+    version?: number | null;
+    publishedAt?: string | null;
+    updatedAt?: string | null;
+    createdAt?: string | null;
+    lastEditedAt?: string | null;
+}
+
+export interface WorldModule {
+    key: string;
+    label: string;
+    status: WorldModuleStatus;
+    fields: Record<string, string>;
+    contentHash?: string | null;
+    fullContent?: string | null;
+    fullContentUpdatedAt?: string | null;
+}
+
+export interface WorldDetail {
+    world: WorldBasicInfo;
+    modules: WorldModule[];
+}
+
+export interface WorldModuleSummary {
+    key: string;
+    label: string;
+}
+
+export interface WorldPublishPreviewMissingField {
+    moduleKey: string;
+    moduleLabel: string;
+    fieldKey: string;
+    fieldLabel: string;
+}
+
+export interface WorldPublishPreview {
+    ready: boolean;
+    moduleStatuses: Record<string, WorldModuleStatus>;
+    missingFields: WorldPublishPreviewMissingField[];
+    modulesToGenerate: WorldModuleSummary[];
+    modulesToReuse: WorldModuleSummary[];
+}
+
+export interface WorldPublishResponse {
+    worldId: number;
+    modulesToGenerate: WorldModuleSummary[];
+    modulesToReuse: WorldModuleSummary[];
+}
+
+export interface WorldGenerationJobStatusEntry {
+    moduleKey: string;
+    moduleLabel: string;
+    status: WorldGenerationJobStatus;
+    attempts?: number | null;
+    startedAt?: string | null;
+    finishedAt?: string | null;
+    error?: string | null;
+}
+
+export interface WorldGenerationStatus {
+    worldId: number;
+    status: WorldStatus;
+    version?: number | null;
+    queue: WorldGenerationJobStatusEntry[];
+}
+
 export interface PromptTemplateMetadata {
     templates: PromptTypeMetadata[];
     functions: PromptFunctionMetadata[];


### PR DESCRIPTION
## Summary
- add defensive error handling when refining world builder fields so backend errors are surfaced and handled gracefully
- disable clearing the published world selector to prevent leaving the editor without a selected world
- normalize file endings on navigation components to satisfy tooling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d07a41c2088330a50fc0e2e264bc3d