### PR TITLE
Implement frontend-driven world generation workflow

### DIFF
--- a/backend/src/main/java/com/example/ainovel/controller/WorldController.java
+++ b/backend/src/main/java/com/example/ainovel/controller/WorldController.java
@@ -183,6 +183,14 @@ public class WorldController {
         return ResponseEntity.ok(status);
     }
 
+    @PostMapping("/{worldId}/generation/{moduleKey}")
+    public ResponseEntity<WorldGenerationStatusResponse> generateModuleFinal(@PathVariable Long worldId,
+                                                                             @PathVariable String moduleKey,
+                                                                             @AuthenticationPrincipal User user) {
+        WorldGenerationStatusResponse status = worldGenerationWorkflowService.generateModule(worldId, moduleKey, user.getId());
+        return ResponseEntity.ok(status);
+    }
+
     @PostMapping("/{worldId}/generation/{moduleKey}/retry")
     public ResponseEntity<Void> retryGeneration(@PathVariable Long worldId,
                                                 @PathVariable String moduleKey,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -537,6 +537,13 @@ export const fetchWorldGenerationStatus = (worldId: number): Promise<WorldGenera
         .then(res => handleResponse<WorldGenerationStatus>(res));
 };
 
+export const runWorldGenerationModule = (worldId: number, moduleKey: string): Promise<WorldGenerationStatus> => {
+    return fetch(`/api/v1/worlds/${worldId}/generation/${moduleKey}`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+    }).then(res => handleResponse<WorldGenerationStatus>(res));
+};
+
 export const retryWorldGeneration = (worldId: number, moduleKey: string): Promise<void> => {
     return fetch(`/api/v1/worlds/${worldId}/generation/${moduleKey}/retry`, {
         method: 'POST',


### PR DESCRIPTION
## Summary
- add an explicit controller endpoint and service workflow to run world-generation jobs on demand instead of through the scheduled worker
- update the world builder UI to orchestrate sequential module generation, resume unfinished runs, and surface progress using the new backend API
- extend tests around the workflow service to cover the new execution path and failure handling, and refresh the default creative-intent placeholder to satisfy validation

## Testing
- `./backend/mvnw test` *(fails: unable to reach Maven Central from the container)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d166e9a0d08330b5fa144f4122aabc