### PR TITLE
Handle world generation retries on frontend and drop backend scheduling

### DIFF
--- a/backend/src/main/java/com/example/ainovel/AinovelApplication.java
+++ b/backend/src/main/java/com/example/ainovel/AinovelApplication.java
@@ -3,11 +3,9 @@ package com.example.ainovel;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.retry.annotation.EnableRetry;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableRetry
-@EnableScheduling
 public class AinovelApplication {
 
         public static void main(String[] args) {


### PR DESCRIPTION
## Summary
- avoid redundant world detail polling by loading details once and managing generation progress through a dedicated effect
- drive world module generation sequentially on the frontend with automatic retry attempts before falling back to manual retry
- remove the unused Spring scheduling configuration so the backend no longer registers timers

## Testing
- npm run lint
- ./mvnw -q -DskipTests package *(fails: unable to reach Maven Central from the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d375ff69dc8330968cb3bed4aeb940