### PR TITLE
Add backend API documentation for all controllers

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -18,6 +18,7 @@
 - 编写新服务时优先使用构造函数注入，复用现有日志与异常处理模式。
 - 需要持久化新配置时，请在 `application*.properties` 中添加默认值，并更新 `doc/getting_started.md` 与 `doc/features.md`。
 - 修改或新增 REST 接口后，请同步更新 Swagger/文档（目前以手工文档为主）。
+- 前端开发联调时请参考 `backend/apidoc/` 中的接口文档；后端增删改接口时务必同步维护该目录内容。
 
 ## 安全与配置
 - 生产环境务必覆盖 `application.properties` 中的示例密钥与数据库凭据。

--- a/backend/apidoc/AiController.md
+++ b/backend/apidoc/AiController.md
@@ -1,0 +1,18 @@
+# AiController 接口文档
+
+## POST /api/v1/ai/generate-dialogue
+- **认证**：需要登录，使用 `@AuthenticationPrincipal` 注入的用户。
+- **功能**：根据传入的角色信息与场景上下文生成对话内容。
+- **请求体**：`CharacterDialogueRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `characterId` | Long | 目标角色卡 ID，用于定位角色记忆。 |
+  | `manuscriptId` | Long | 所属手稿 ID，便于加载相关记忆。 |
+  | `currentSceneDescription` | String | 当前场景描述，提供上下文。 |
+  | `dialogueTopic` | String | 本次对话主题。 |
+- **响应**：`200 OK`
+  - `CharacterDialogueResponse`
+    | 字段 | 类型 | 说明 |
+    | --- | --- | --- |
+    | `dialogue` | String | 模型生成的对话正文。 |
+- **主要逻辑**：调用 `CharacterDialogueService.generateDialogue(request, userId)` 根据用户 ID 与请求内容生成结果，再以 200 返回。

--- a/backend/apidoc/AuthController.md
+++ b/backend/apidoc/AuthController.md
@@ -1,0 +1,43 @@
+# AuthController 接口文档
+
+## POST /api/v1/auth/register
+- **认证**：匿名。
+- **功能**：注册新用户。
+- **请求体**：`RegisterRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `username` | String | 用户名。 |
+  | `password` | String | 密码。 |
+  | `email` | String | 邮箱。 |
+- **响应**：
+  - 成功：`201 Created`，`{"message": "User registered successfully"}`。
+  - 失败：`400 Bad Request`，返回 `message` 说明失败原因。
+- **主要逻辑**：调用 `AuthService.register` 执行注册，捕获 `IllegalArgumentException` 返回 400。
+
+## POST /api/v1/auth/login
+- **认证**：匿名。
+- **功能**：登录并获取 JWT。
+- **请求体**：`LoginRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `username` | String | 用户名。 |
+  | `password` | String | 密码。 |
+- **响应**：
+  - 成功：`200 OK`，`{"token": "<JWT>"}`。
+  - 失败：`401 Unauthorized`，`{"message": "Invalid username or password"}`。
+- **主要逻辑**：调用 `AuthService.login` 校验凭证并生成 JWT。
+
+## GET /api/v1/auth/validate
+- **认证**：请求头 `Authorization: Bearer <token>`。
+- **功能**：校验 JWT 是否有效，并返回基础权限信息。
+- **请求参数**：无额外路径参数。
+- **响应**：
+  - 成功：`200 OK`，返回字段：
+    | 字段 | 类型 | 说明 |
+    | --- | --- | --- |
+    | `username` | String | JWT 内的用户名。 |
+    | `userId` | Long | 当前用户 ID。 |
+    | `workspaceId` | Long | 当前工作空间 ID（等于用户 ID）。 |
+    | `permissions` | Map<String, List<String>> | 每个资源对应的权限级别枚举名称列表。 |
+  - 失败：`401 Unauthorized`，无 body。
+- **主要逻辑**：解析 `Authorization` 头获取 token，使用 `JwtUtil.validateToken` 校验后查询 `PermissionService.findPermissionsForWorkspace`。异常时返回 401。

--- a/backend/apidoc/ConceptionController.md
+++ b/backend/apidoc/ConceptionController.md
@@ -1,0 +1,94 @@
+# ConceptionController 接口文档
+
+基础路径：`/api/v1`
+
+## POST /api/v1/conception
+- **认证**：需要登录。
+- **功能**：根据设定生成故事卡及角色卡并保存。
+- **请求体**：`ConceptionRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `idea` | String | 故事核心创意或提示。 |
+  | `genre` | String | 故事类型。 |
+  | `tone` | String | 故事风格。 |
+  | `tags` | List<String> | 额外标签。 |
+  | `worldId` | Long | 可选，引用发布世界以增强生成。 |
+- **响应**：`200 OK`
+  - `ConceptionResponse`
+    | 字段 | 类型 | 说明 |
+    | --- | --- | --- |
+    | `storyCard` | StoryCard | 生成并保存的故事卡，含 `id/title/genre/tone/synopsis/storyArc/worldId` 等字段。 |
+    | `characterCards` | List<CharacterCard> | 关联角色卡列表，含 `id/name/synopsis/details/relationships/avatarUrl` 等。 |
+- **主要逻辑**：调用 `ConceptionService.generateAndSaveStory`，使用登录用户名保存生成结果。
+
+## GET /api/v1/story-cards
+- **认证**：需要登录。
+- **功能**：获取当前用户的全部故事卡。
+- **响应**：`200 OK`，返回 `List<StoryCard>`。
+- **主要逻辑**：`ConceptionService.getAllStoryCards(user.getUsername())`。
+
+## GET /api/v1/story-cards/{id}
+- **认证**：需要登录。
+- **功能**：按 ID 获取故事卡详情。
+- **路径参数**：`id` 故事卡 ID。
+- **响应**：`200 OK`，返回 `StoryCard`。
+- **主要逻辑**：校验归属后调用 `ConceptionService.getStoryCardById(id, userId)`。
+
+## GET /api/v1/story-cards/{storyId}/character-cards
+- **认证**：需要登录。
+- **功能**：列出指定故事下的全部角色卡。
+- **路径参数**：`storyId` 故事卡 ID。
+- **响应**：`200 OK`，返回 `List<CharacterCard>`。
+- **主要逻辑**：`ConceptionService.getCharacterCardsByStoryId(storyId, userId)`。
+
+## PUT /api/v1/story-cards/{id}
+- **认证**：需要登录。
+- **功能**：更新故事卡内容。
+- **路径参数**：`id` 故事卡 ID。
+- **请求体**：`StoryCard`（支持更新 `title/genre/tone/synopsis/storyArc/worldId` 等字段）。
+- **响应**：`200 OK`，返回更新后的 `StoryCard`。
+- **主要逻辑**：`ConceptionService.updateStoryCard(id, body, userId)`。
+
+## PUT /api/v1/character-cards/{id}
+- **认证**：需要登录。
+- **功能**：更新角色卡。
+- **路径参数**：`id` 角色卡 ID。
+- **请求体**：`CharacterCard`（支持更新 `name/synopsis/details/relationships/avatarUrl` 等字段）。
+- **响应**：`200 OK`，返回更新后的 `CharacterCard`。
+- **主要逻辑**：`ConceptionService.updateCharacterCard(id, body, userId)`。
+
+## POST /api/v1/story-cards/{storyCardId}/characters
+- **认证**：需要登录。
+- **功能**：为指定故事新增角色卡。
+- **路径参数**：`storyCardId` 故事卡 ID。
+- **请求体**：`CharacterCard`（至少需要 `name`，可附带简介/关系等）。
+- **响应**：`200 OK`，返回新建的 `CharacterCard`。
+- **主要逻辑**：`ConceptionService.addCharacterToStory(storyCardId, body, user)`。
+
+## DELETE /api/v1/character-cards/{id}
+- **认证**：需要登录。
+- **功能**：删除角色卡。
+- **路径参数**：`id` 角色卡 ID。
+- **响应**：`204 No Content`。
+- **主要逻辑**：`ConceptionService.deleteCharacterCard(id, userId)`。
+
+## POST /api/v1/story-cards/{id}/refine
+- **认证**：需要登录。
+- **功能**：对故事卡的指定字段进行 AI 优化。
+- **路径参数**：`id` 故事卡 ID。
+- **请求体**：`RefineRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `text` | String | 原文本。 |
+  | `instruction` | String | 优化指令。 |
+  | `contextType` | String | 文本类型标识。 |
+- **响应**：`200 OK`，`RefineResponse`，字段 `refinedText` 为优化结果。
+- **主要逻辑**：`ConceptionService.refineStoryCardField(id, request, user)`。
+
+## POST /api/v1/character-cards/{id}/refine
+- **认证**：需要登录。
+- **功能**：对角色卡字段进行 AI 优化。
+- **路径参数**：`id` 角色卡 ID。
+- **请求体**：`RefineRequest`（字段同上）。
+- **响应**：`200 OK`，`RefineResponse`。
+- **主要逻辑**：`ConceptionService.refineCharacterCardField(id, request, user)`。

--- a/backend/apidoc/ManuscriptController.md
+++ b/backend/apidoc/ManuscriptController.md
@@ -1,0 +1,91 @@
+# ManuscriptController 接口文档
+
+基础路径：`/api/v1`
+
+## GET /api/v1/manuscript/outlines/{outlineId}
+- **认证**：需要登录。
+- **功能**：按旧版兼容接口获取某大纲下各场景的激活手稿段落。
+- **路径参数**：`outlineId` 大纲 ID。
+- **响应**：`200 OK`，返回 `Map<Long, ManuscriptSection>`，键为场景 ID，值为段落实体（含 `id/sceneId/content/version/isActive/createdAt`）。
+- **主要逻辑**：`ManuscriptService.getManuscriptForOutline(outlineId, userId)`。
+
+## POST /api/v1/manuscript/scenes/{sceneId}/generate
+- **认证**：需要登录。
+- **功能**：为指定场景生成手稿内容并写入最新手稿。
+- **路径参数**：`sceneId` 场景 ID。
+- **请求体**：可选 `GenerateManuscriptSectionRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `worldId` | Long | 可选，指定生成时使用的世界设定。 |
+- **响应**：`200 OK`，返回生成的 `ManuscriptSection`。
+- **主要逻辑**：`ManuscriptService.generateSceneContent(sceneId, userId, worldId)`。
+
+## PUT /api/v1/manuscript/sections/{sectionId}
+- **认证**：需要登录。
+- **功能**：更新手稿段落正文。
+- **路径参数**：`sectionId` 手稿段落 ID。
+- **请求体**：`UpdateSectionRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `content` | String | 新的段落内容。 |
+- **响应**：`200 OK`，返回更新后的 `ManuscriptSection`。
+- **主要逻辑**：`ManuscriptService.updateSectionContent(sectionId, content, userId)`。
+
+## POST /api/v1/manuscripts/{manuscriptId}/sections/analyze-character-changes
+- **认证**：需要登录。
+- **功能**：分析并保存某段落涉及的角色变化。
+- **路径参数**：`manuscriptId` 手稿 ID。
+- **请求体**：`AnalyzeCharacterChangesRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `chapterNumber` | Integer | 所在章编号。 |
+  | `sectionNumber` | Integer | 段落编号。 |
+  | `sectionContent` | String | 待分析内容。 |
+  | `characterIds` | List<Long> | 涉及的角色 ID 列表。 |
+- **响应**：`200 OK`，`List<CharacterChangeLogDto>`，包含角色变化、关系变化、自动复制标识等。
+- **主要逻辑**：`ManuscriptService.analyzeCharacterChanges(manuscriptId, request, userId)`。
+
+## GET /api/v1/manuscripts/{manuscriptId}/character-change-logs
+- **认证**：需要登录。
+- **功能**：列出某手稿下全部角色变更日志。
+- **路径参数**：`manuscriptId` 手稿 ID。
+- **响应**：`200 OK`，`List<CharacterChangeLogDto>`。
+- **主要逻辑**：`ManuscriptService.getCharacterChangeLogs(manuscriptId, userId)`。
+
+## GET /api/v1/manuscripts/{manuscriptId}/character-change-logs/{characterId}
+- **认证**：需要登录。
+- **功能**：查看指定角色的变更日志。
+- **路径参数**：`manuscriptId` 手稿 ID；`characterId` 角色 ID。
+- **响应**：`200 OK`，`List<CharacterChangeLogDto>`。
+- **主要逻辑**：`ManuscriptService.getCharacterChangeLogsForCharacter(manuscriptId, characterId, userId)`。
+
+## GET /api/v1/outlines/{outlineId}/manuscripts
+- **认证**：需要登录。
+- **功能**：列出某大纲下的手稿概览。
+- **路径参数**：`outlineId` 大纲 ID。
+- **响应**：`200 OK`，返回 `List<ManuscriptDto>`（含 `id/title/outlineId/worldId/createdAt/updatedAt`）。
+- **主要逻辑**：`ManuscriptService.getManuscriptsForOutline(outlineId, userId)`。
+
+## POST /api/v1/outlines/{outlineId}/manuscripts
+- **认证**：需要登录。
+- **功能**：在大纲下创建新手稿。
+- **路径参数**：`outlineId` 大纲 ID。
+- **请求体**：`ManuscriptDto`（至少包含 `title`，可带 `worldId`）。
+- **响应**：`200 OK`，返回创建后的 `ManuscriptDto`。
+- **主要逻辑**：`ManuscriptService.createManuscript(outlineId, dto, userId)`。
+
+## GET /api/v1/manuscripts/{manuscriptId}
+- **认证**：需要登录。
+- **功能**：获取手稿详情及激活段落映射。
+- **路径参数**：`manuscriptId` 手稿 ID。
+- **响应**：`200 OK`，`ManuscriptWithSectionsDto`
+  - `manuscript`：`ManuscriptDto`
+  - `sections`：`Map<Long, ManuscriptSection>`。
+- **主要逻辑**：`ManuscriptService.getManuscriptWithSections(manuscriptId, userId)`。
+
+## DELETE /api/v1/manuscripts/{manuscriptId}
+- **认证**：需要登录。
+- **功能**：删除手稿及其段落。
+- **路径参数**：`manuscriptId` 手稿 ID。
+- **响应**：`204 No Content`。
+- **主要逻辑**：`ManuscriptService.deleteManuscript(manuscriptId, userId)`。

--- a/backend/apidoc/MaterialController.md
+++ b/backend/apidoc/MaterialController.md
@@ -1,0 +1,165 @@
+# MaterialController 接口文档
+
+基础路径：`/api/v1/materials`
+
+## POST /api/v1/materials
+- **认证**：需要登录。
+- **功能**：手动创建素材。
+- **请求体**：`MaterialCreateRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `title` | String | 素材标题。 |
+  | `type` | String | 素材类型（如角色、地点等）。 |
+  | `summary` | String | 摘要。 |
+  | `content` | String | 具体内容。 |
+  | `tags` | String | 标签，通常为逗号分隔字符串。 |
+- **响应**：
+  - 成功：`201 Created`，返回 `MaterialResponse`（含 `id/workspaceId/title/type/summary/tags/status/entitiesJson/reviewNotes/createdAt/updatedAt`）。
+  - 参数错误：`400 Bad Request`，包含 `message`。
+- **主要逻辑**：使用用户 ID 同时作为 workspace ID 创建素材，捕获非法参数。
+
+## GET /api/v1/materials
+- **认证**：需要登录。
+- **功能**：列出当前工作空间的全部素材。
+- **响应**：`200 OK`，`List<MaterialResponse>`。
+- **主要逻辑**：`MaterialService.listMaterials(workspaceId)`。
+
+## GET /api/v1/materials/{materialId}
+- **认证**：需要登录。
+- **功能**：查看素材详情（含正文）。
+- **路径参数**：`materialId` 素材 ID。
+- **响应**：
+  - 成功：`200 OK`，`MaterialDetailResponse`（在 `MaterialResponse` 基础上新增 `content`）。
+  - 不存在：`404 Not Found`，返回 `message`。
+- **主要逻辑**：`MaterialService.getMaterialDetail(materialId, workspaceId)`。
+
+## PUT /api/v1/materials/{materialId}
+- **认证**：需要登录。
+- **功能**：更新素材属性与内容。
+- **路径参数**：`materialId`。
+- **请求体**：`MaterialUpdateRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `title` | String | 标题。 |
+  | `type` | String | 类型。 |
+  | `summary` | String | 摘要。 |
+  | `tags` | String | 标签。 |
+  | `content` | String | 正文。 |
+  | `status` | String | 状态枚举，例如 `draft`/`published`。 |
+  | `entitiesJson` | String | 结构化实体 JSON。 |
+- **响应**：
+  - 成功：`200 OK`，返回更新后的 `MaterialDetailResponse`。
+  - 业务异常：`400 Bad Request`，包含 `message`。
+- **主要逻辑**：`MaterialService.updateMaterial(materialId, workspaceId, userId, request)`。
+
+## DELETE /api/v1/materials/{materialId}
+- **认证**：需要登录。
+- **功能**：删除素材。
+- **响应**：
+  - 成功：`204 No Content`。
+  - 未找到：`404 Not Found`，包含 `message`。
+- **主要逻辑**：`MaterialService.deleteMaterial(materialId, workspaceId, userId)`。
+
+## POST /api/v1/materials/search
+- **认证**：需要登录。
+- **功能**：关键词检索素材。
+- **请求体**：`MaterialSearchRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `query` | String | 搜索关键字。 |
+  | `limit` | Integer | 期望条数，后端会限制在 1-20。 |
+- **响应**：`200 OK`，返回搜索结果列表（`MaterialResponse` 的精简视图）。
+- **主要逻辑**：根据 limit 取最小值，调用 `MaterialService.searchMaterials`。
+
+## POST /api/v1/materials/find-duplicates
+- **认证**：需要登录。
+- **功能**：检测可能重复的素材。
+- **响应**：`200 OK`，返回 `List<MaterialDuplicateCandidate>`（含相似度、重叠片段信息）。
+- **主要逻辑**：`DeduplicationService.findDuplicates(workspaceId)`。
+
+## POST /api/v1/materials/merge
+- **认证**：需要登录。
+- **功能**：合并两个素材。
+- **请求体**：`MaterialMergeRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `sourceMaterialId` | Long | 来源素材 ID。 |
+  | `targetMaterialId` | Long | 目标素材 ID。 |
+  | `mergeTags` | boolean | 是否合并标签。 |
+  | `mergeSummaryWhenEmpty` | boolean | 目标摘要为空时是否合并。 |
+  | `note` | String | 备注。 |
+- **响应**：
+  - 成功：`200 OK`，返回合并后的 `MaterialResponse`。
+  - 业务异常：`400 Bad Request`，包含 `message`。
+- **主要逻辑**：`DeduplicationService.mergeMaterials(workspaceId, userId, request)`。
+
+## POST /api/v1/materials/upload
+- **认证**：需要登录。
+- **功能**：上传文件触发素材导入作业。
+- **请求参数**：`file` (MultipartFile)。
+- **响应**：
+  - 成功：`202 Accepted`，返回 `FileImportJobResponse`（含作业 ID、状态、错误信息等）。
+  - 参数错误：`400 Bad Request`，包含 `message`。
+  - IO 异常：`500 Internal Server Error`，包含 `message` 和 `detail`。
+- **主要逻辑**：`FileImportService.startFileImportJob`。
+
+## GET /api/v1/materials/upload/{jobId}
+- **认证**：需要登录。
+- **功能**：查询文件导入作业状态。
+- **路径参数**：`jobId`。
+- **响应**：
+  - 成功：`200 OK`，`FileImportJobResponse`。
+  - 未找到：`404 Not Found`，`message`。
+- **主要逻辑**：`FileImportService.getJobStatus(jobId, workspaceId)`。
+
+## GET /api/v1/materials/review/pending
+- **认证**：需要登录。
+- **功能**：列出待审核素材。
+- **响应**：`200 OK`，返回 `List<MaterialReviewItem>`。
+- **主要逻辑**：`MaterialService.listPendingReview(workspaceId)`。
+
+## POST /api/v1/materials/{materialId}/review/approve
+- **认证**：需要登录。
+- **功能**：审核通过素材，可选更新信息。
+- **路径参数**：`materialId`。
+- **请求体**（可选）：`MaterialReviewDecisionRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `title` | String | 更新后的标题。 |
+  | `summary` | String | 更新后的摘要。 |
+  | `tags` | String | 标签。 |
+  | `entitiesJson` | String | 实体 JSON。 |
+  | `type` | String | 类型。 |
+  | `reviewNotes` | String | 审核备注。 |
+- **响应**：
+  - 成功：`200 OK`，返回 `MaterialReviewItem`。
+  - 失败：`400 Bad Request`，`message`。
+- **主要逻辑**：`MaterialService.approveMaterial(materialId, workspaceId, userId, request)`。
+
+## POST /api/v1/materials/{materialId}/review/reject
+- **认证**：需要登录。
+- **功能**：驳回素材，同步记录备注。
+- **请求体**：可选 `MaterialReviewDecisionRequest`（字段同上）。
+- **响应**：同通过接口。
+- **主要逻辑**：`MaterialService.rejectMaterial(materialId, workspaceId, userId, request)`。
+
+## POST /api/v1/materials/editor/auto-hints
+- **认证**：需要登录。
+- **功能**：根据编辑器文本自动推荐素材引用。
+- **请求体**：`EditorContextDto`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `text` | String | 当前编辑器文本片段。 |
+  | `workspaceId` | Long | 可选，指定工作空间，缺省使用用户 ID。 |
+  | `limit` | Integer | 可选，结果条数上限（1-15，默认 6）。 |
+- **响应**：`200 OK`，返回匹配的素材列表；若文本为空返回空数组。
+- **主要逻辑**：预处理文本后调用 `MaterialService.searchMaterials`。
+
+## GET /api/v1/materials/{materialId}/citations
+- **认证**：需要登录。
+- **功能**：查看素材被引用情况。
+- **路径参数**：`materialId`。
+- **响应**：
+  - 成功：`200 OK`，`List<MaterialCitationDto>`（含引用文档信息、使用场景、时间）。
+  - 失败：`400 Bad Request`，`message`。
+- **主要逻辑**：`MaterialAuditQueryService.listCitations(workspaceId, materialId)`。

--- a/backend/apidoc/OutlineController.md
+++ b/backend/apidoc/OutlineController.md
@@ -1,0 +1,93 @@
+# OutlineController 接口文档
+
+基础路径：`/api/v1`
+
+## POST /api/v1/outlines *(已废弃)*
+- **认证**：需要登录。
+- **功能**：旧版生成整套大纲接口，现已返回 410。
+- **响应**：`410 Gone`。
+
+## POST /api/v1/outlines/{outlineId}/chapters
+- **认证**：需要登录。
+- **功能**：为现有大纲生成单章结构。
+- **路径参数**：`outlineId` 大纲 ID。
+- **请求体**：`GenerateChapterRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `chapterNumber` | int | 章节序号。 |
+  | `sectionsPerChapter` | int | 期望场景数。 |
+  | `wordsPerSection` | int | 每场景目标字数。 |
+  | `worldId` | Long | 可选，覆盖默认世界设定。 |
+- **响应**：`200 OK`，`ChapterDto`（含 `id/chapterNumber/title/synopsis/scenes/settings`）。
+- **主要逻辑**：`OutlineService.generateChapterOutline`。
+
+## GET /api/v1/outlines/{id}
+- **认证**：需要登录。
+- **功能**：获取指定大纲详情。
+- **路径参数**：`id` 大纲 ID。
+- **响应**：`200 OK`，`OutlineDto`（含 `id/title/pointOfView/chapters/worldId/createdAt`）。
+- **主要逻辑**：`OutlineService.getOutlineById(id, userId)`。
+
+## GET /api/v1/story-cards/{storyCardId}/outlines
+- **认证**：需要登录。
+- **功能**：根据故事卡列出关联大纲。
+- **路径参数**：`storyCardId`。
+- **响应**：`200 OK`，`List<OutlineDto>`。
+- **主要逻辑**：`OutlineService.getOutlinesByStoryCardId(storyCardId, userId)`。
+
+## GET /api/v1/stories/{storyId}/outlines
+- **认证**：需要登录。
+- **功能**：同上，提供 `/stories` 别名。
+- **响应**：`200 OK`，`List<OutlineDto>`。
+
+## POST /api/v1/story-cards/{storyCardId}/outlines
+- **认证**：需要登录。
+- **功能**：为故事创建空白大纲。
+- **路径参数**：`storyCardId`。
+- **响应**：`200 OK`，`OutlineDto`。
+- **主要逻辑**：`OutlineService.createEmptyOutline(storyCardId, userId)`。
+
+## PUT /api/v1/outlines/{id}
+- **认证**：需要登录。
+- **功能**：完整更新大纲。
+- **路径参数**：`id` 大纲 ID。
+- **请求体**：`OutlineDto`（包括章节/场景树）。
+- **响应**：`200 OK`，更新后的 `OutlineDto`。
+- **主要逻辑**：`OutlineService.updateOutline(id, dto, userId)`。
+
+## DELETE /api/v1/outlines/{id}
+- **认证**：需要登录。
+- **功能**：删除大纲。
+- **响应**：`204 No Content`。
+- **主要逻辑**：`OutlineService.deleteOutline(id, userId)`。
+
+## POST /api/v1/outlines/scenes/{id}/refine
+- **认证**：需要登录。
+- **功能**：对场景梗概进行 AI 优化。
+- **路径参数**：`id` 场景 ID。
+- **请求体**：`RefineRequest`（`text/instruction/contextType`）。
+- **响应**：`200 OK`，`RefineResponse`（`refinedText`）。
+- **主要逻辑**：`OutlineService.refineScene(id, request, user)`。
+
+## POST /api/v1/ai/refine-text
+- **认证**：需要登录。
+- **功能**：通用文本润色。
+- **请求体**：`RefineRequest`。
+- **响应**：`200 OK`，`RefineResponse`。
+- **主要逻辑**：`OutlineService.refineGenericText(request, user)`。
+
+## PATCH /api/v1/chapters/{id}
+- **认证**：需要登录。
+- **功能**：局部更新章节信息。
+- **路径参数**：`id` 章节 ID。
+- **请求体**：`ChapterDto`（允许部分字段）。
+- **响应**：`200 OK`，更新后的 `ChapterDto`。
+- **主要逻辑**：`OutlineService.updateChapter(id, dto, userId)`。
+
+## PATCH /api/v1/scenes/{id}
+- **认证**：需要登录。
+- **功能**：局部更新场景信息。
+- **路径参数**：`id` 场景 ID。
+- **请求体**：`SceneDto`（可更新 `synopsis/expectedWords/presentCharacterIds/presentCharacters/sceneCharacters/temporaryCharacters` 等）。
+- **响应**：`200 OK`，更新后的 `SceneDto`。
+- **主要逻辑**：`OutlineService.updateScene(id, dto, userId)`。

--- a/backend/apidoc/PromptTemplateController.md
+++ b/backend/apidoc/PromptTemplateController.md
@@ -1,0 +1,48 @@
+# PromptTemplateController 接口文档
+
+基础路径：`/api/v1/prompt-templates`
+
+## GET /api/v1/prompt-templates
+- **认证**：需要登录（若未登录会拿不到个性化模板）。
+- **功能**：获取生效的故事/大纲/手稿/润色提示模板。
+- **响应**：`200 OK`，`PromptTemplatesResponse`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `storyCreation` | PromptTemplateItemDto | 创建故事模板（含默认值、自定义内容、更新时间等）。 |
+  | `outlineChapter` | PromptTemplateItemDto | 生成章节模板。 |
+  | `manuscriptSection` | PromptTemplateItemDto | 生成手稿段落模板。 |
+  | `refine` | RefinePromptTemplateDto | 润色模板（含带指令与无指令版本）。 |
+- **主要逻辑**：`PromptTemplateService.getEffectiveTemplates(userId)`。
+
+## PUT /api/v1/prompt-templates
+- **认证**：需要登录。
+- **功能**：保存用户自定义模板。
+- **请求体**：`PromptTemplatesUpdateRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `storyCreation` | String | 自定义故事模板。 |
+  | `outlineChapter` | String | 自定义章节模板。 |
+  | `manuscriptSection` | String | 自定义手稿模板。 |
+  | `refine` | RefinePromptTemplatesUpdateRequest | 润色模板更新（`withInstruction/withoutInstruction`）。 |
+- **响应**：`200 OK`，无 body。
+- **主要逻辑**：`PromptTemplateService.saveTemplates(userId, request)`。
+
+## POST /api/v1/prompt-templates/reset
+- **认证**：需要登录。
+- **功能**：按 key 恢复默认模板。
+- **请求体**：`PromptTemplatesResetRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `keys` | List<String> | 需要重置的模板标识，如 `storyCreation`。 |
+- **响应**：`200 OK`，无 body。
+- **主要逻辑**：`PromptTemplateService.resetTemplates(userId, request)`。
+
+## GET /api/v1/prompt-templates/metadata
+- **认证**：无需登录。
+- **功能**：获取模板语法、变量、函数说明。
+- **响应**：`200 OK`，`PromptTemplateMetadataResponse`
+  - `templates`：模板类型元数据。
+  - `functions`：可用函数说明。
+  - `syntaxTips`：语法提示。
+  - `examples`：示例。
+- **主要逻辑**：`PromptTemplateService.getMetadata()`。

--- a/backend/apidoc/SettingsController.md
+++ b/backend/apidoc/SettingsController.md
@@ -1,0 +1,32 @@
+# SettingsController 接口文档
+
+基础路径：`/api/v1/settings`
+
+## GET /api/v1/settings
+- **认证**：需要登录。
+- **功能**：获取当前用户的 AI 设置。
+- **响应**：`200 OK`，`SettingsDto`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `baseUrl` | String | 模型调用基础地址。 |
+  | `modelName` | String | 使用的模型名称。 |
+  | `apiKey` | String | 仅在更新请求中使用；响应中不会返回明文。 |
+  | `customPrompt` | String | 自定义系统提示。 |
+  | `apiKeyIsSet` | boolean | 是否已配置 API Key。 |
+- **主要逻辑**：`SettingsService.getSettings(username)`。
+
+## PUT /api/v1/settings
+- **认证**：需要登录。
+- **功能**：更新 AI 设置。
+- **请求体**：`SettingsDto`（填写需更新的字段；`apiKey` 若不为空会覆盖原值）。
+- **响应**：`200 OK`，无 body。
+- **主要逻辑**：`SettingsService.updateSettings(username, dto)`。
+
+## POST /api/v1/settings/test
+- **认证**：需要登录。
+- **功能**：验证当前设置能否成功连接到模型服务。
+- **请求体**：`SettingsDto`（提供待测 provider/密钥等）。
+- **响应**：
+  - 成功：`200 OK`，`{"message": "Connection successful!"}`。
+  - 失败：`400 Bad Request`，`{"message": "Connection test failed. Please check your API key and provider."}`。
+- **主要逻辑**：`SettingsService.testConnectionForUser(userId, dto)`，返回布尔结果决定状态码。

--- a/backend/apidoc/StoryController.md
+++ b/backend/apidoc/StoryController.md
@@ -1,0 +1,30 @@
+# StoryController 接口文档
+
+基础路径：`/api/v1/stories`
+
+## POST /api/v1/stories
+- **认证**：需要登录。
+- **功能**：创建新的故事卡。
+- **请求体**：`StoryCardDto`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `title` | String | 故事标题。 |
+  | `synopsis` | String | 故事简介。 |
+  | `genre` | String | 类型。 |
+  | `tone` | String | 风格。 |
+  | `worldId` | Long | 可选，关联世界。 |
+- **响应**：`201 Created`，返回持久化后的 `StoryCard`（含生成的 `id` 及时间戳等完整字段）。
+- **主要逻辑**：`StoryService.createStory(user, dto)`。
+
+## GET /api/v1/stories
+- **认证**：需要登录。
+- **功能**：列出当前用户的故事卡。
+- **响应**：`200 OK`，`List<StoryCardDto>`。
+- **主要逻辑**：`StoryService.getUserStories(userId)`。
+
+## DELETE /api/v1/stories/{storyId}
+- **认证**：需要登录。
+- **功能**：删除指定故事及级联资源。
+- **路径参数**：`storyId`。
+- **响应**：`204 No Content`。
+- **主要逻辑**：`StoryService.deleteStory(storyId, userId)`。

--- a/backend/apidoc/WorldBuildingDefinitionController.md
+++ b/backend/apidoc/WorldBuildingDefinitionController.md
@@ -1,0 +1,15 @@
+# WorldBuildingDefinitionController 接口文档
+
+基础路径：`/api/v1/world-building/definitions`
+
+## GET /api/v1/world-building/definitions
+- **认证**：无需登录。
+- **功能**：提供世界观编辑器使用的模块/字段定义、字段润色模板与提示上下文。
+- **响应**：`200 OK`，`WorldBuildingDefinitionResponse`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `basicInfo` | WorldBasicInfoDefinitionDto | 世界基础信息配置。 |
+  | `modules` | List<WorldModuleDefinitionDto> | 各模块的字段与描述。 |
+  | `fieldRefineTemplate` | WorldFieldRefineTemplateDto | 字段润色模板。 |
+  | `promptContext` | WorldPromptContextDefinitionDto | Prompt 上下文定义。 |
+- **主要逻辑**：`WorldBuildingDefinitionService.getDefinitions()` 直接返回静态配置。

--- a/backend/apidoc/WorldController.md
+++ b/backend/apidoc/WorldController.md
@@ -1,0 +1,118 @@
+# WorldController 接口文档
+
+基础路径：`/api/v1/worlds`
+
+## POST /api/v1/worlds
+- **认证**：需要登录。
+- **功能**：创建世界及模块初始数据。
+- **请求体**：`WorldUpsertRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `name` | String | 世界名称。 |
+  | `tagline` | String | 宣传语。 |
+  | `themes` | List<String> | 主题标签。 |
+  | `creativeIntent` | String | 创作意图。 |
+  | `notes` | String | 备注。 |
+- **响应**：`201 Created`，`WorldDetailResponse`（包含世界基础信息与模块列表）。
+- **主要逻辑**：`WorldService.createWorld(user, request)` 并通过 `WorldDtoMapper` 组装响应。
+
+## GET /api/v1/worlds
+- **认证**：需要登录。
+- **功能**：按状态筛选世界列表。
+- **查询参数**：`status` 可选，支持 `draft/published` 等，`all` 或为空表示不过滤。
+- **响应**：`200 OK`，`List<WorldSummaryResponse>`（含世界状态、版本、模块进度）。
+- **主要逻辑**：`WorldService.listWorlds(userId, filter)`。
+
+## GET /api/v1/worlds/{worldId}
+- **认证**：需要登录。
+- **功能**：获取世界详情及模块概要。
+- **响应**：`200 OK`，`WorldDetailResponse`。
+- **主要逻辑**：`WorldService.getWorld(worldId, userId)`。
+
+## GET /api/v1/worlds/{worldId}/full
+- **认证**：需要登录。
+- **功能**：获取已发布版本的完整模块文本。
+- **响应**：`200 OK`，`WorldFullResponse`（含 `world` 信息与模块 `fullContent`/`excerpt`）。
+- **主要逻辑**：`WorldService.getPublishedWorldWithModules`。
+
+## PUT /api/v1/worlds/{worldId}
+- **认证**：需要登录。
+- **功能**：更新世界基础信息。
+- **请求体**：`WorldUpsertRequest`。
+- **响应**：`200 OK`，`WorldDetailResponse`。
+- **主要逻辑**：`WorldService.updateWorld(worldId, userId, request)`。
+
+## DELETE /api/v1/worlds/{worldId}
+- **认证**：需要登录。
+- **功能**：删除世界。
+- **响应**：`204 No Content`。
+- **主要逻辑**：`WorldService.deleteWorld(worldId, userId)`。
+
+## PUT /api/v1/worlds/{worldId}/modules/{moduleKey}
+- **认证**：需要登录。
+- **功能**：更新单个模块字段。
+- **请求体**：`WorldModuleUpdateRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `fields` | Map<String, String> | 字段键值对。 |
+- **响应**：`200 OK`，`WorldModuleResponse`（包含模块状态、字段内容、全文等）。
+- **主要逻辑**：`WorldModuleService.updateModule(worldId, userId, moduleKey, request)`。
+
+## PUT /api/v1/worlds/{worldId}/modules
+- **认证**：需要登录。
+- **功能**：批量更新多个模块。
+- **请求体**：`WorldModulesBatchUpdateRequest`
+  - `modules`：数组，每项 `ModuleUpdate` 包含 `key` 与 `fields`。
+- **响应**：`200 OK`，`List<WorldModuleResponse>`。
+- **主要逻辑**：`WorldModuleService.updateModules(worldId, userId, request)`。
+
+## POST /api/v1/worlds/{worldId}/modules/{moduleKey}/generate
+- **认证**：需要登录。
+- **功能**：调用 AI 生成指定模块内容。
+- **响应**：`200 OK`，`WorldModuleResponse`。
+- **主要逻辑**：`WorldModuleGenerationService.generateModule(worldId, moduleKey, userId)`。
+
+## POST /api/v1/worlds/{worldId}/modules/{moduleKey}/fields/{fieldKey}/refine
+- **认证**：需要登录。
+- **功能**：对模块内单个字段进行润色。
+- **请求体**：`WorldFieldRefineRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `text` | String | 原文。 |
+  | `instruction` | String | 优化指令。 |
+- **响应**：`200 OK`，`WorldFieldRefineResponse`（`result` 为优化结果）。
+- **主要逻辑**：`WorldFieldRefineService.refineField(worldId, moduleKey, fieldKey, userId, request)`。
+
+## GET /api/v1/worlds/{worldId}/publish/preview
+- **认证**：需要登录。
+- **功能**：检查发布所需字段是否齐全。
+- **响应**：`200 OK`，`WorldPublishPreviewResponse`
+  - `ready`：是否可以发布。
+  - `moduleStatuses`：各模块状态。
+  - `missingFields`：缺失字段列表。
+  - `modulesToGenerate` / `modulesToReuse`：发布时需处理的模块概览。
+- **主要逻辑**：`WorldPublicationService.preview(worldId, userId)`。
+
+## POST /api/v1/worlds/{worldId}/publish
+- **认证**：需要登录。
+- **功能**：准备发布，返回需要生成/复用的模块计划。
+- **响应**：`200 OK`，`WorldPublishResponse`。
+- **主要逻辑**：`WorldPublicationService.preparePublish(worldId, userId)`。
+
+## GET /api/v1/worlds/{worldId}/generation
+- **认证**：需要登录。
+- **功能**：查询世界模块生成任务进度。
+- **响应**：`200 OK`，`WorldGenerationStatusResponse`（包含队列中各模块的状态、尝试次数、时间戳等）。
+- **主要逻辑**：`WorldGenerationWorkflowService.getStatus(worldId, userId)`。
+
+## POST /api/v1/worlds/{worldId}/generation/{moduleKey}
+- **认证**：需要登录。
+- **功能**：触发生成队列中的指定模块。
+- **响应**：`200 OK`，更新后的 `WorldGenerationStatusResponse`。
+- **主要逻辑**：`WorldGenerationWorkflowService.generateModule(worldId, moduleKey, userId)`。
+
+## POST /api/v1/worlds/{worldId}/generation/{moduleKey}/retry
+- **认证**：需要登录。
+- **功能**：对失败模块重新排队生成。
+- **响应**：`204 No Content`。
+- **主要逻辑**：`WorldGenerationWorkflowService.retryModule(worldId, moduleKey, userId)`。

--- a/backend/apidoc/WorldPromptTemplateController.md
+++ b/backend/apidoc/WorldPromptTemplateController.md
@@ -1,0 +1,44 @@
+# WorldPromptTemplateController 接口文档
+
+基础路径：`/api/v1/world-prompts`
+
+## GET /api/v1/world-prompts
+- **认证**：需要登录（未登录返回公共默认）。
+- **功能**：获取世界生成相关的模块模板、终稿模板及字段润色模板。
+- **响应**：`200 OK`，`WorldPromptTemplatesResponse`
+  - `modules`：Map，键为模块 key，值为 `WorldPromptTemplateItemDto`。
+  - `finalTemplates`：Map，终稿模板集合。
+  - `fieldRefine`：`WorldPromptTemplateItemDto`，字段润色模板。
+- **主要逻辑**：`WorldPromptTemplateService.getEffectiveTemplates(userId)`。
+
+## PUT /api/v1/world-prompts
+- **认证**：需要登录。
+- **功能**：保存自定义世界模板。
+- **请求体**：`WorldPromptTemplatesUpdateRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `modules` | Map<String, String> | 每个模块的自定义模板文本。 |
+  | `finalTemplates` | Map<String, String> | 终稿模板文本。 |
+  | `fieldRefine` | String | 字段润色模板。 |
+- **响应**：`200 OK`，无 body。
+- **主要逻辑**：`WorldPromptTemplateService.saveTemplates(userId, request)`。
+
+## POST /api/v1/world-prompts/reset
+- **认证**：需要登录。
+- **功能**：按 key 重置世界模板。
+- **请求体**：`WorldPromptTemplatesResetRequest`
+  | 字段 | 类型 | 说明 |
+  | --- | --- | --- |
+  | `keys` | List<String> | 待重置的模板 key。 |
+- **响应**：`200 OK`，无 body。
+- **主要逻辑**：`WorldPromptTemplateService.resetTemplates(userId, request)`。
+
+## GET /api/v1/world-prompts/metadata
+- **认证**：无需登录。
+- **功能**：查看世界模板支持的模块结构、变量、函数与示例。
+- **响应**：`200 OK`，`WorldPromptTemplateMetadataResponse`
+  - `modules`：模块元数据列表。
+  - `variables`：变量说明。 
+  - `functions`：函数说明。
+  - `examples`：模板示例。 
+- **主要逻辑**：`WorldPromptTemplateService.getMetadata()`。


### PR DESCRIPTION
## Summary
- add backend/apidoc directory with Markdown references for each controller endpoint
- document request parameters, response shapes, and key logic details
- update backend agent guide to require keeping backend/apidoc in sync for frontend/backend work

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690be659af8083309d93c5bd88fa7adc)